### PR TITLE
feat: add Shelly Blu H&T Outside sensor MAC

### DIFF
--- a/zigbee_sensor_reader/config.py
+++ b/zigbee_sensor_reader/config.py
@@ -92,8 +92,7 @@ ZONES: dict[str, str] = {
 # Shelly Blu H&T sensors (keyed by BLE MAC address, uppercase with colons)
 # Run `python -m zigbee_sensor_reader --discover-shelly` to find MAC addresses
 SHELLY_SENSORS: dict[str, str] = {
-    # MAC will be populated after first discovery scan
-    # "AA:BB:CC:DD:EE:FF": "Outside",
+    "94:B2:16:08:82:98": "Outside",
 }
 
 # BLE scan duration for Shelly sensors (seconds)


### PR DESCRIPTION
Adds MAC 94:B2:16:08:82:98 (SBHT-003C) as Outside sensor in SHELLY_SENSORS config.