### PR TITLE
Add SNZB-02DR2 device daily min/max temp to DB and dashboard

### DIFF
--- a/zigbee_sensor_reader/__main__.py
+++ b/zigbee_sensor_reader/__main__.py
@@ -45,6 +45,8 @@ def handle_reading(reading, conn) -> None:
         battery_pct=reading.battery_pct,
         link_quality=reading.link_quality,
         zone=zone,
+        device_min_temp_c=getattr(reading, "device_min_temp_c", None),
+        device_max_temp_c=getattr(reading, "device_max_temp_c", None),
     )
 
     parts = [f"[{reading.friendly_name}]"]
@@ -56,6 +58,10 @@ def handle_reading(reading, conn) -> None:
         parts.append(f"Humidity: {reading.humidity_pct:.1f}%")
     if reading.battery_pct is not None:
         parts.append(f"Battery: {reading.battery_pct:.0f}%")
+    dmin = getattr(reading, "device_min_temp_c", None)
+    dmax = getattr(reading, "device_max_temp_c", None)
+    if dmin is not None and dmax is not None:
+        parts.append(f"Device min/max: {dmin:.1f}/{dmax:.1f}°C")
     print("  ".join(parts))
 
 

--- a/zigbee_sensor_reader/database.py
+++ b/zigbee_sensor_reader/database.py
@@ -72,6 +72,8 @@ def _create_tables(conn: sqlite3.Connection) -> None:
         ("readings", "boost_on", "INTEGER"),
         ("readings", "target_temp_c", "REAL"),
         ("readings", "heating_mode", "TEXT"),
+        ("readings", "device_min_temp_c", "REAL"),
+        ("readings", "device_max_temp_c", "REAL"),
     ]
     for table, col, col_type in migrations:
         try:
@@ -117,6 +119,8 @@ def insert_reading(
     boost_on: bool | None = None,
     target_temp_c: float | None = None,
     heating_mode: str | None = None,
+    device_min_temp_c: float | None = None,
+    device_max_temp_c: float | None = None,
 ) -> None:
     """Store a single sensor reading."""
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
@@ -125,11 +129,13 @@ def insert_reading(
     conn.execute(
         """
         INSERT INTO readings (ieee_address, timestamp, temperature_c, humidity_pct,
-            battery_pct, link_quality, zone, heating_on, boost_on, target_temp_c, heating_mode)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            battery_pct, link_quality, zone, heating_on, boost_on, target_temp_c,
+            heating_mode, device_min_temp_c, device_max_temp_c)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (ieee_address, now, temperature_c, humidity_pct, battery_pct, link_quality,
-         zone, heating_int, boost_int, target_temp_c, heating_mode),
+         zone, heating_int, boost_int, target_temp_c, heating_mode,
+         device_min_temp_c, device_max_temp_c),
     )
     # Also touch the sensor's last_seen
     conn.execute(

--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -120,7 +120,8 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
         """
         SELECT r.ieee_address, s.friendly_name, s.model, r.timestamp,
                r.temperature_c, r.humidity_pct, r.battery_pct, r.zone,
-               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode
+               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode,
+               r.device_min_temp_c, r.device_max_temp_c
         FROM readings r
         INNER JOIN (
             SELECT ieee_address, MAX(timestamp) AS max_ts
@@ -188,10 +189,14 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
 
         sensor_row = {
             **latest,
+            # DB-computed daily min/max (from all readings today)
             "min_temp_c": daily.get("min_temp_c"),
             "max_temp_c": daily.get("max_temp_c"),
             "min_humidity_pct": daily.get("min_humidity_pct"),
             "max_humidity_pct": daily.get("max_humidity_pct"),
+            # Device-reported daily min/max (from ZCL attributes 0x0001/0x0002)
+            "device_min_temp_c": latest.get("device_min_temp_c"),
+            "device_max_temp_c": latest.get("device_max_temp_c"),
         }
 
         if model.startswith("SNZB-02"):
@@ -280,8 +285,8 @@ def dashboard():
   <table>
     <thead>
       <tr>
-        <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (C)</th><th>Humidity (%)</th>
-        <th>Daily Low/High Temp (C)</th><th>Daily Low/High Humidity (%)</th>
+        <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (°C)</th><th>Humidity (%)</th>
+        <th>Device Min/Max Temp (°C)</th><th>Today Low/High Temp (°C)</th><th>Today Low/High Humidity (%)</th>
       </tr>
     </thead>
     <tbody>
@@ -292,6 +297,11 @@ def dashboard():
         <td>{{ s.timestamp }}</td>
         <td>{% if s.temperature_c is not none %}{{ "%.1f"|format(s.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if s.humidity_pct is not none %}{{ "%.1f"|format(s.humidity_pct) }}{% else %}-{% endif %}</td>
+        <td>
+          {% if s.device_min_temp_c is not none and s.device_max_temp_c is not none %}
+            {{ "%.1f"|format(s.device_min_temp_c) }} / {{ "%.1f"|format(s.device_max_temp_c) }}
+          {% else %}-{% endif %}
+        </td>
         <td>
           {% if s.min_temp_c is not none and s.max_temp_c is not none %}
             {{ "%.1f"|format(s.min_temp_c) }} / {{ "%.1f"|format(s.max_temp_c) }}

--- a/zigbee_sensor_reader/zigbee_reader.py
+++ b/zigbee_sensor_reader/zigbee_reader.py
@@ -37,6 +37,8 @@ class SensorReading:
         humidity_pct: float | None = None,
         battery_pct: float | None = None,
         link_quality: int | None = None,
+        device_min_temp_c: float | None = None,
+        device_max_temp_c: float | None = None,
     ):
         self.ieee_address = ieee_address
         self.friendly_name = friendly_name
@@ -45,6 +47,8 @@ class SensorReading:
         self.humidity_pct = humidity_pct
         self.battery_pct = battery_pct
         self.link_quality = link_quality
+        self.device_min_temp_c = device_min_temp_c
+        self.device_max_temp_c = device_max_temp_c
 
     def __repr__(self) -> str:
         return (
@@ -306,12 +310,22 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
             temp = None
             humidity = None
             battery = None
+            device_min_temp = None
+            device_max_temp = None
 
             if TemperatureMeasurement.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[TemperatureMeasurement.cluster_id]
                 val = cluster.get(0x0000)  # measured_value
                 if val is not None:
                     temp = val / 100.0
+                # 0x0001 = min_measured_value, 0x0002 = max_measured_value
+                # On SNZB-02DR2 these hold the device's rolling daily min/max
+                min_val = cluster.get(0x0001)
+                max_val = cluster.get(0x0002)
+                if min_val is not None and min_val != 0x8000:  # 0x8000 = invalid/unset
+                    device_min_temp = min_val / 100.0
+                if max_val is not None and max_val != 0x8000:
+                    device_max_temp = max_val / 100.0
 
             if RelativeHumidity.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[RelativeHumidity.cluster_id]
@@ -333,6 +347,8 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
                     temperature_c=temp,
                     humidity_pct=humidity,
                     battery_pct=battery,
+                    device_min_temp_c=device_min_temp,
+                    device_max_temp_c=device_max_temp,
                 ))
 
     return readings


### PR DESCRIPTION
- Reads ZCL TemperatureMeasurement attrs 0x0001/0x0002 from zigpy cache
- Stores device_min_temp_c / device_max_temp_c in readings table (auto-migration)
- Wires through __main__.py (also logs to console)
- Dashboard: new 'Device Min/Max Temp' column for Sonoff sensors