### PR TITLE
Capture all available sensor data + Hive hot water

### DIFF
--- a/zigbee_sensor_reader/__main__.py
+++ b/zigbee_sensor_reader/__main__.py
@@ -47,6 +47,9 @@ def handle_reading(reading, conn) -> None:
         zone=zone,
         device_min_temp_c=getattr(reading, "device_min_temp_c", None),
         device_max_temp_c=getattr(reading, "device_max_temp_c", None),
+        device_min_humidity_pct=getattr(reading, "device_min_humidity_pct", None),
+        device_max_humidity_pct=getattr(reading, "device_max_humidity_pct", None),
+        battery_voltage_mv=getattr(reading, "battery_voltage_mv", None),
     )
 
     parts = [f"[{reading.friendly_name}]"]
@@ -58,6 +61,9 @@ def handle_reading(reading, conn) -> None:
         parts.append(f"Humidity: {reading.humidity_pct:.1f}%")
     if reading.battery_pct is not None:
         parts.append(f"Battery: {reading.battery_pct:.0f}%")
+    bv = getattr(reading, "battery_voltage_mv", None)
+    if bv is not None:
+        parts.append(f"V: {bv/1000:.2f}V")
     dmin = getattr(reading, "device_min_temp_c", None)
     dmax = getattr(reading, "device_max_temp_c", None)
     if dmin is not None and dmax is not None:

--- a/zigbee_sensor_reader/__main__.py
+++ b/zigbee_sensor_reader/__main__.py
@@ -45,6 +45,8 @@ def handle_reading(reading, conn) -> None:
         battery_pct=reading.battery_pct,
         link_quality=reading.link_quality,
         zone=zone,
+        device_min_temp_c=getattr(reading, "device_min_temp_c", None),
+        device_max_temp_c=getattr(reading, "device_max_temp_c", None),
     )
 
     parts = [f"[{reading.friendly_name}]"]
@@ -56,6 +58,10 @@ def handle_reading(reading, conn) -> None:
         parts.append(f"Humidity: {reading.humidity_pct:.1f}%")
     if reading.battery_pct is not None:
         parts.append(f"Battery: {reading.battery_pct:.0f}%")
+    dmin = getattr(reading, "device_min_temp_c", None)
+    dmax = getattr(reading, "device_max_temp_c", None)
+    if dmin is not None and dmax is not None:
+        parts.append(f"Device min/max: {dmin:.1f}/{dmax:.1f}°C")
     print("  ".join(parts))
 
 

--- a/zigbee_sensor_reader/database.py
+++ b/zigbee_sensor_reader/database.py
@@ -72,6 +72,8 @@ def _create_tables(conn: sqlite3.Connection) -> None:
         ("readings", "boost_on", "INTEGER"),
         ("readings", "target_temp_c", "REAL"),
         ("readings", "heating_mode", "TEXT"),
+        ("readings", "device_min_temp_c", "REAL"),
+        ("readings", "device_max_temp_c", "REAL"),
     ]
     for table, col, col_type in migrations:
         try:
@@ -117,6 +119,8 @@ def insert_reading(
     boost_on: bool | None = None,
     target_temp_c: float | None = None,
     heating_mode: str | None = None,
+    device_min_temp_c: float | None = None,
+    device_max_temp_c: float | None = None,
 ) -> None:
     """Store a single sensor reading."""
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
@@ -125,11 +129,13 @@ def insert_reading(
     conn.execute(
         """
         INSERT INTO readings (ieee_address, timestamp, temperature_c, humidity_pct,
-            battery_pct, link_quality, zone, heating_on, boost_on, target_temp_c, heating_mode)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            battery_pct, link_quality, zone, heating_on, boost_on, target_temp_c,
+            heating_mode, device_min_temp_c, device_max_temp_c)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (ieee_address, now, temperature_c, humidity_pct, battery_pct, link_quality,
-         zone, heating_int, boost_int, target_temp_c, heating_mode),
+         zone, heating_int, boost_int, target_temp_c, heating_mode,
+         device_min_temp_c, device_max_temp_c),
     )
     # Also touch the sensor's last_seen
     conn.execute(

--- a/zigbee_sensor_reader/database.py
+++ b/zigbee_sensor_reader/database.py
@@ -74,6 +74,10 @@ def _create_tables(conn: sqlite3.Connection) -> None:
         ("readings", "heating_mode", "TEXT"),
         ("readings", "device_min_temp_c", "REAL"),
         ("readings", "device_max_temp_c", "REAL"),
+        ("readings", "device_min_humidity_pct", "REAL"),
+        ("readings", "device_max_humidity_pct", "REAL"),
+        ("readings", "battery_voltage_mv", "REAL"),
+        ("readings", "rssi", "INTEGER"),
     ]
     for table, col, col_type in migrations:
         try:
@@ -121,6 +125,10 @@ def insert_reading(
     heating_mode: str | None = None,
     device_min_temp_c: float | None = None,
     device_max_temp_c: float | None = None,
+    device_min_humidity_pct: float | None = None,
+    device_max_humidity_pct: float | None = None,
+    battery_voltage_mv: float | None = None,
+    rssi: int | None = None,
 ) -> None:
     """Store a single sensor reading."""
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
@@ -130,12 +138,16 @@ def insert_reading(
         """
         INSERT INTO readings (ieee_address, timestamp, temperature_c, humidity_pct,
             battery_pct, link_quality, zone, heating_on, boost_on, target_temp_c,
-            heating_mode, device_min_temp_c, device_max_temp_c)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            heating_mode, device_min_temp_c, device_max_temp_c,
+            device_min_humidity_pct, device_max_humidity_pct,
+            battery_voltage_mv, rssi)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (ieee_address, now, temperature_c, humidity_pct, battery_pct, link_quality,
          zone, heating_int, boost_int, target_temp_c, heating_mode,
-         device_min_temp_c, device_max_temp_c),
+         device_min_temp_c, device_max_temp_c,
+         device_min_humidity_pct, device_max_humidity_pct,
+         battery_voltage_mv, rssi),
     )
     # Also touch the sensor's last_seen
     conn.execute(

--- a/zigbee_sensor_reader/hive_reader.py
+++ b/zigbee_sensor_reader/hive_reader.py
@@ -24,12 +24,13 @@ HIVE_USERNAME = os.environ.get("HIVE_USERNAME", "")
 HIVE_PASSWORD = os.environ.get("HIVE_PASSWORD", "")
 
 
-async def fetch_hive_data() -> list[dict]:
+async def fetch_hive_data() -> dict:
     """
-    Connect to the Hive API and fetch thermostat data.
+    Connect to the Hive API and fetch thermostat + hot water data.
 
-    Returns a list of dicts with keys:
-        name, device_id, temperature_c, target_temp_c, mode, battery_pct
+    Returns a dict with keys:
+        "heating": list of heating dicts
+        "hotwater": list of hot water dicts
     """
     from apyhiveapi import Hive
 
@@ -38,7 +39,7 @@ async def fetch_hive_data() -> list[dict]:
             "Hive credentials not set. Set HIVE_USERNAME and HIVE_PASSWORD "
             "environment variables."
         )
-        return []
+        return {"heating": [], "hotwater": []}
 
     try:
         # Login and start session
@@ -51,31 +52,26 @@ async def fetch_hive_data() -> list[dict]:
                 "Hive account requires SMS 2FA. This is not supported in "
                 "unattended mode. Disable 2FA or use an app-specific password."
             )
-            return []
+            return {"heating": [], "hotwater": []}
 
         session = await hive.startSession()
 
-        results = []
+        heating_results = []
+        hotwater_results = []
 
-        # Iterate over climate (thermostat) devices
+        # ── Heating thermostats ─────────────────────────────────────────────
         for dev in session.get("climate", []):
             hive_name = dev.get("hiveName", "Unknown")
             device_id = dev.get("hiveID", dev.get("device_id", "unknown"))
-            # Use friendly name from config, fall back to Hive's name
             friendly_name = HIVE_NAMES.get(hive_name, hive_name)
 
             try:
-                # Get current and target temperature via the heating helper
                 temp = await hive.heating.getCurrentTemperature(dev)
                 target = await hive.heating.getTargetTemperature(dev)
                 mode = await hive.heating.getMode(dev)
                 state = await hive.heating.getState(dev)
                 boost = await hive.heating.getBoostStatus(dev)
-
-                # Battery from deviceData
                 battery = dev.get("deviceData", {}).get("battery")
-
-                # Heating is on if state is not OFF
                 heating_on = state not in ("OFF", None, False)
 
                 heating_data = {
@@ -89,11 +85,10 @@ async def fetch_hive_data() -> list[dict]:
                     "battery_pct": battery,
                     "zone": ZONES.get(hive_name),
                 }
-
-                results.append(heating_data)
+                heating_results.append(heating_data)
                 heat_status = "HEATING" if heating_on else "off"
                 logger.info(
-                    "Hive %s: %.1f°C (target: %.1f°C, mode: %s, heating: %s)",
+                    "Hive heating %s: %.1f°C (target: %.1f°C, mode: %s, heating: %s)",
                     friendly_name,
                     heating_data["temperature_c"] or 0,
                     heating_data["target_temp_c"] or 0,
@@ -101,20 +96,57 @@ async def fetch_hive_data() -> list[dict]:
                     heat_status,
                 )
             except Exception as e:
-                logger.warning("Failed to read Hive device %s: %s", friendly_name, e)
+                logger.warning("Failed to read Hive heating %s: %s", friendly_name, e)
 
-        return results
+        # ── Hot water ───────────────────────────────────────────────────────
+        # Try both common key names across library versions
+        hw_devices = (
+            session.get("water_heater")
+            or session.get("hotwater")
+            or getattr(hive, "device_list", {}).get("water_heater")
+            or []
+        )
+        for dev in hw_devices:
+            hive_name = dev.get("hiveName", dev.get("hive_name", "Hot Water"))
+            device_id = dev.get("hiveID", dev.get("device_id", "hotwater"))
+            friendly_name = HIVE_NAMES.get(hive_name, hive_name)
+
+            try:
+                mode = await hive.hotwater.get_mode(dev)
+                state = await hive.hotwater.get_state(dev)
+                boost = await hive.hotwater.get_boost_status(dev)
+
+                hw_on = state not in ("OFF", None, False)
+                boost_active = boost not in ("OFF", None, False)
+
+                hw_data = {
+                    "name": friendly_name,
+                    "device_id": device_id,
+                    "hw_on": hw_on,
+                    "mode": mode,
+                    "boost": boost_active,
+                    "zone": ZONES.get(hive_name),
+                }
+                hotwater_results.append(hw_data)
+                logger.info(
+                    "Hive hot water %s: state=%s, mode=%s, boost=%s",
+                    friendly_name, "ON" if hw_on else "OFF", mode, boost,
+                )
+            except Exception as e:
+                logger.warning("Failed to read Hive hot water %s: %s", friendly_name, e)
+
+        return {"heating": heating_results, "hotwater": hotwater_results}
 
     except Exception as e:
         logger.error("Hive API error: %s", e)
-        return []
+        return {"heating": [], "hotwater": []}
 
 
-def store_hive_readings(readings: list[dict]) -> None:
-    """Store Hive thermostat readings in the same SQLite database."""
+def store_hive_readings(data: dict) -> None:
+    """Store Hive heating + hot water readings in SQLite."""
     conn = get_connection()
 
-    for reading in readings:
+    for reading in data.get("heating", []):
         # Use "hive:" prefix to distinguish from Zigbee sensors
         ieee_address = f"hive:{reading['device_id']}"
         friendly_name = f"Hive {reading['name']}"
@@ -141,17 +173,42 @@ def store_hive_readings(readings: list[dict]) -> None:
             heating_mode=reading.get("mode"),
         )
 
+    for hw in data.get("hotwater", []):
+        # "hive-hw:" prefix distinguishes hot water from heating thermostats
+        ieee_address = f"hive-hw:{hw['device_id']}"
+        friendly_name = f"Hive Hot Water"
+        zone = hw.get("zone")
+
+        upsert_sensor(
+            conn,
+            ieee_address=ieee_address,
+            friendly_name=friendly_name,
+            model="Hive Hot Water",
+            zone=zone,
+        )
+
+        insert_reading(
+            conn,
+            ieee_address=ieee_address,
+            temperature_c=None,  # hot water cylinder has no temp sensor
+            humidity_pct=None,
+            zone=zone,
+            heating_on=hw.get("hw_on"),    # True when actively heating water
+            boost_on=hw.get("boost"),
+            heating_mode=hw.get("mode"),   # SCHEDULE / ON / OFF / BOOST
+        )
+
     conn.close()
 
 
-async def poll_hive() -> list[dict]:
-    """Fetch and store Hive thermostat data."""
-    readings = await fetch_hive_data()
-    if readings:
-        store_hive_readings(readings)
-    return readings
+async def poll_hive() -> dict:
+    """Fetch and store Hive heating + hot water data."""
+    data = await fetch_hive_data()
+    if data["heating"] or data["hotwater"]:
+        store_hive_readings(data)
+    return data
 
 
-def run_hive_poll() -> list[dict]:
+def run_hive_poll() -> dict:
     """Synchronous wrapper for poll_hive."""
     return asyncio.run(poll_hive())

--- a/zigbee_sensor_reader/shelly_ble_reader.py
+++ b/zigbee_sensor_reader/shelly_ble_reader.py
@@ -215,6 +215,8 @@ async def poll_shelly_ble(scan_duration: float = 60.0) -> list[dict]:
             humidity_pct=data.get("humidity"),
             battery_pct=data.get("battery"),
             zone=zone,
+            battery_voltage_mv=data.get("voltage") * 1000 if data.get("voltage") is not None else None,
+            rssi=data.get("rssi"),
         )
 
         stored.append(data)

--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -153,6 +153,7 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
     sonoff = []
     shelly = []
     hive = []
+    hotwater = []
 
     for row in latest_rows:
         ieee_address = row["ieee_address"]
@@ -164,6 +165,26 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
             if configured_name:
                 latest["friendly_name"] = configured_name
         daily = daily_by_sensor.get(ieee_address, {})
+
+        if ieee_address.startswith("hive-hw:"):
+            # Hive hot water — state/mode only, no temperature
+            hw_on = row["heating_on"] == 1
+            boost_on = row["boost_on"] == 1
+            if boost_on:
+                status = "boost"
+            elif hw_on:
+                status = "on"
+            else:
+                status = "off"
+            hotwater.append({
+                **latest,
+                "status": status,
+                "runtime_today_seconds": hive_runtime_seconds.get(ieee_address, 0.0),
+                "runtime_today_hhmm": _format_duration_hhmm(
+                    hive_runtime_seconds.get(ieee_address, 0.0)
+                ),
+            })
+            continue
 
         if ieee_address.startswith("hive:"):
             heating_on = row["heating_on"] == 1
@@ -206,6 +227,7 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
 
     sonoff.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
     hive.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
+    hotwater.sort(key=lambda row: (row.get("friendly_name") or row.get("ieee_address")))
     shelly.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
 
     return {
@@ -217,6 +239,7 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
         "sonoff": sonoff,
         "shelly": shelly,
         "hive": hive,
+        "hotwater": hotwater,
     }
 
 
@@ -321,8 +344,8 @@ def dashboard():
   <table>
     <thead>
       <tr>
-        <th>Thermostat</th><th>Zone</th><th>Timestamp</th><th>Current Temp (C)</th>
-        <th>Target Temp (C)</th><th>Mode</th><th>Status</th><th>Daily Runtime (HH:MM)</th>
+        <th>Thermostat</th><th>Zone</th><th>Timestamp</th><th>Current Temp (°C)</th>
+        <th>Target Temp (°C)</th><th>Mode</th><th>Status</th><th>Daily Runtime (HH:MM)</th>
       </tr>
     </thead>
     <tbody>
@@ -341,12 +364,36 @@ def dashboard():
     </tbody>
   </table>
 
+  <h2>Hive Hot Water</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Device</th><th>Timestamp</th><th>Mode</th><th>Status</th><th>Daily Runtime (HH:MM)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for h in hotwater %}
+      <tr>
+        <td>{{ h.friendly_name or h.ieee_address }}</td>
+        <td>{{ h.timestamp }}</td>
+        <td>{{ h.heating_mode or "-" }}</td>
+        <td class="status-{{ h.status }}">{{ h.status }}</td>
+        <td>{{ h.runtime_today_hhmm }}</td>
+      </tr>
+      {% endfor %}
+      {% if not hotwater %}
+      <tr><td colspan="5" style="color:#999">No hot water data yet</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+
   <h2>Shelly Blu H&amp;T</h2>
   <table>
     <thead>
       <tr>
-        <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (C)</th><th>Humidity (%)</th><th>Battery (%)</th>
-        <th>Daily Low/High Temp (C)</th><th>Daily Low/High Humidity (%)</th>
+        <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (°C)</th><th>Humidity (%)</th>
+        <th>Battery (%)</th><th>Voltage (V)</th><th>RSSI</th>
+        <th>Today Low/High Temp (°C)</th><th>Today Low/High Humidity (%)</th>
       </tr>
     </thead>
     <tbody>
@@ -358,6 +405,8 @@ def dashboard():
         <td>{% if s.temperature_c is not none %}{{ "%.1f"|format(s.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if s.humidity_pct is not none %}{{ "%.1f"|format(s.humidity_pct) }}{% else %}-{% endif %}</td>
         <td>{% if s.battery_pct is not none %}{{ "%.0f"|format(s.battery_pct) }}{% else %}-{% endif %}</td>
+        <td>{% if s.battery_voltage_mv is not none %}{{ "%.2f"|format(s.battery_voltage_mv / 1000) }}{% else %}-{% endif %}</td>
+        <td>{% if s.rssi is not none %}{{ s.rssi }}{% else %}-{% endif %}</td>
         <td>
           {% if s.min_temp_c is not none and s.max_temp_c is not none %}
             {{ "%.1f"|format(s.min_temp_c) }} / {{ "%.1f"|format(s.max_temp_c) }}
@@ -408,9 +457,11 @@ def api_readings():
 
     query = """
         SELECT r.ieee_address, s.friendly_name, r.timestamp,
-               r.temperature_c, r.humidity_pct, r.battery_pct,
-               r.zone, r.heating_on, r.boost_on,
-               r.target_temp_c, r.heating_mode
+               r.temperature_c, r.humidity_pct, r.battery_pct, r.battery_voltage_mv,
+               r.link_quality, r.rssi, r.zone,
+               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode,
+               r.device_min_temp_c, r.device_max_temp_c,
+               r.device_min_humidity_pct, r.device_max_humidity_pct
         FROM readings r
         LEFT JOIN sensors s ON r.ieee_address = s.ieee_address
         WHERE 1=1
@@ -449,9 +500,11 @@ def api_readings_latest():
     conn = get_db()
     rows = conn.execute("""
         SELECT r.ieee_address, s.friendly_name, r.timestamp,
-               r.temperature_c, r.humidity_pct, r.battery_pct,
-               r.zone, r.heating_on, r.boost_on,
-               r.target_temp_c, r.heating_mode
+               r.temperature_c, r.humidity_pct, r.battery_pct, r.battery_voltage_mv,
+               r.link_quality, r.rssi, r.zone,
+               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode,
+               r.device_min_temp_c, r.device_max_temp_c,
+               r.device_min_humidity_pct, r.device_max_humidity_pct
         FROM readings r
         INNER JOIN (
             SELECT ieee_address, MAX(timestamp) as max_ts
@@ -479,9 +532,11 @@ def api_export_csv():
 
     query = """
         SELECT r.ieee_address, s.friendly_name, r.timestamp,
-               r.temperature_c, r.humidity_pct, r.battery_pct,
-               r.zone, r.heating_on, r.boost_on,
-               r.target_temp_c, r.heating_mode
+               r.temperature_c, r.humidity_pct, r.battery_pct, r.battery_voltage_mv,
+               r.link_quality, r.rssi, r.zone,
+               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode,
+               r.device_min_temp_c, r.device_max_temp_c,
+               r.device_min_humidity_pct, r.device_max_humidity_pct
         FROM readings r
         LEFT JOIN sensors s ON r.ieee_address = s.ieee_address
         WHERE 1=1

--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -120,7 +120,8 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
         """
         SELECT r.ieee_address, s.friendly_name, s.model, r.timestamp,
                r.temperature_c, r.humidity_pct, r.battery_pct, r.zone,
-               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode
+               r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode,
+               r.device_min_temp_c, r.device_max_temp_c
         FROM readings r
         INNER JOIN (
             SELECT ieee_address, MAX(timestamp) AS max_ts
@@ -188,10 +189,14 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
 
         sensor_row = {
             **latest,
+            # DB-computed daily min/max (from all readings today)
             "min_temp_c": daily.get("min_temp_c"),
             "max_temp_c": daily.get("max_temp_c"),
             "min_humidity_pct": daily.get("min_humidity_pct"),
             "max_humidity_pct": daily.get("max_humidity_pct"),
+            # Device-reported daily min/max (from ZCL attributes 0x0001/0x0002)
+            "device_min_temp_c": latest.get("device_min_temp_c"),
+            "device_max_temp_c": latest.get("device_max_temp_c"),
         }
 
         if model.startswith("SNZB-02"):
@@ -280,8 +285,8 @@ def dashboard():
   <table>
     <thead>
       <tr>
-        <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (C)</th><th>Humidity (%)</th>
-        <th>Daily Low/High Temp (C)</th><th>Daily Low/High Humidity (%)</th>
+        <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (°C)</th><th>Humidity (%)</th>
+        <th>Device Min/Max Temp (°C)</th><th>Today Low/High Temp (°C)</th><th>Today Low/High Humidity (%)</th>
       </tr>
     </thead>
     <tbody>
@@ -292,6 +297,11 @@ def dashboard():
         <td>{{ s.timestamp }}</td>
         <td>{% if s.temperature_c is not none %}{{ "%.1f"|format(s.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if s.humidity_pct is not none %}{{ "%.1f"|format(s.humidity_pct) }}{% else %}-{% endif %}</td>
+        <td>
+          {% if s.device_min_temp_c is not none and s.device_max_temp_c is not none %}
+            {{ "%.1f"|format(s.device_min_temp_c) }} / {{ "%.1f"|format(s.device_max_temp_c) }}
+          {% else %}-{% endif %}
+        </td>
         <td>
           {% if s.min_temp_c is not none and s.max_temp_c is not none %}
             {{ "%.1f"|format(s.min_temp_c) }} / {{ "%.1f"|format(s.max_temp_c) }}

--- a/zigbee_sensor_reader/zigbee_reader.py
+++ b/zigbee_sensor_reader/zigbee_reader.py
@@ -39,6 +39,9 @@ class SensorReading:
         link_quality: int | None = None,
         device_min_temp_c: float | None = None,
         device_max_temp_c: float | None = None,
+        device_min_humidity_pct: float | None = None,
+        device_max_humidity_pct: float | None = None,
+        battery_voltage_mv: float | None = None,
     ):
         self.ieee_address = ieee_address
         self.friendly_name = friendly_name
@@ -49,6 +52,9 @@ class SensorReading:
         self.link_quality = link_quality
         self.device_min_temp_c = device_min_temp_c
         self.device_max_temp_c = device_max_temp_c
+        self.device_min_humidity_pct = device_min_humidity_pct
+        self.device_max_humidity_pct = device_max_humidity_pct
+        self.battery_voltage_mv = battery_voltage_mv
 
     def __repr__(self) -> str:
         return (
@@ -310,15 +316,18 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
             temp = None
             humidity = None
             battery = None
+            battery_voltage = None
             device_min_temp = None
             device_max_temp = None
+            device_min_humidity = None
+            device_max_humidity = None
 
             if TemperatureMeasurement.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[TemperatureMeasurement.cluster_id]
                 val = cluster.get(0x0000)  # measured_value
                 if val is not None:
                     temp = val / 100.0
-                # 0x0001 = min_measured_value, 0x0002 = max_measured_value
+                # 0x0001/0x0002 = min/max_measured_value
                 # On SNZB-02DR2 these hold the device's rolling daily min/max
                 min_val = cluster.get(0x0001)
                 max_val = cluster.get(0x0002)
@@ -332,12 +341,25 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
                 val = cluster.get(0x0000)
                 if val is not None:
                     humidity = val / 100.0
+                # 0x0001/0x0002 = min/max measured humidity (if supported)
+                min_val = cluster.get(0x0001)
+                max_val = cluster.get(0x0002)
+                if min_val is not None and min_val != 0xFFFF:
+                    device_min_humidity = min_val / 100.0
+                if max_val is not None and max_val != 0xFFFF:
+                    device_max_humidity = max_val / 100.0
 
             if PowerConfiguration.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[PowerConfiguration.cluster_id]
-                val = cluster.get(0x0021)  # battery_percentage_remaining
+                val = cluster.get(0x0021)  # battery_percentage_remaining (0-200 → %)
                 if val is not None:
                     battery = val / 2.0
+                volt_val = cluster.get(0x0020)  # battery_voltage (units: 100 mV)
+                if volt_val is not None:
+                    battery_voltage = volt_val * 100.0  # store as mV
+
+            # LQI from device neighbour table (best-effort; may be None)
+            lqi = getattr(device, "lqi", None)
 
             if temp is not None or humidity is not None:
                 readings.append(SensorReading(
@@ -347,8 +369,12 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
                     temperature_c=temp,
                     humidity_pct=humidity,
                     battery_pct=battery,
+                    link_quality=lqi,
                     device_min_temp_c=device_min_temp,
                     device_max_temp_c=device_max_temp,
+                    device_min_humidity_pct=device_min_humidity,
+                    device_max_humidity_pct=device_max_humidity,
+                    battery_voltage_mv=battery_voltage,
                 ))
 
     return readings

--- a/zigbee_sensor_reader/zigbee_reader.py
+++ b/zigbee_sensor_reader/zigbee_reader.py
@@ -37,6 +37,8 @@ class SensorReading:
         humidity_pct: float | None = None,
         battery_pct: float | None = None,
         link_quality: int | None = None,
+        device_min_temp_c: float | None = None,
+        device_max_temp_c: float | None = None,
     ):
         self.ieee_address = ieee_address
         self.friendly_name = friendly_name
@@ -45,6 +47,8 @@ class SensorReading:
         self.humidity_pct = humidity_pct
         self.battery_pct = battery_pct
         self.link_quality = link_quality
+        self.device_min_temp_c = device_min_temp_c
+        self.device_max_temp_c = device_max_temp_c
 
     def __repr__(self) -> str:
         return (
@@ -306,12 +310,22 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
             temp = None
             humidity = None
             battery = None
+            device_min_temp = None
+            device_max_temp = None
 
             if TemperatureMeasurement.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[TemperatureMeasurement.cluster_id]
                 val = cluster.get(0x0000)  # measured_value
                 if val is not None:
                     temp = val / 100.0
+                # 0x0001 = min_measured_value, 0x0002 = max_measured_value
+                # On SNZB-02DR2 these hold the device's rolling daily min/max
+                min_val = cluster.get(0x0001)
+                max_val = cluster.get(0x0002)
+                if min_val is not None and min_val != 0x8000:  # 0x8000 = invalid/unset
+                    device_min_temp = min_val / 100.0
+                if max_val is not None and max_val != 0x8000:
+                    device_max_temp = max_val / 100.0
 
             if RelativeHumidity.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[RelativeHumidity.cluster_id]
@@ -333,6 +347,8 @@ def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:
                     temperature_c=temp,
                     humidity_pct=humidity,
                     battery_pct=battery,
+                    device_min_temp_c=device_min_temp,
+                    device_max_temp_c=device_max_temp,
                 ))
 
     return readings


### PR DESCRIPTION
### New data captured

**Sonoff SNZB-02D/DR2 (Zigbee)**
- \attery_voltage_mv\ — ZCL PowerConfig attr 0x0020 (units: 100mV → stored as mV)
- \device_min_humidity_pct\ / \device_max_humidity_pct\ — ZCL RelHumidity attrs 0x0001/0x0002 (device rolling daily min/max)
- \link_quality\ — from zigpy \device.lqi\ (best-effort; populated when available)

**Shelly Blu H&T**
- \ssi\ — BLE signal strength (was collected but not stored)
- \attery_voltage_mv\ — BTHome 0x0A voltage object (was parsed but not stored)

**Hive hot water (new — \hive-hw:\ prefix)**
- Polled in the same API session as heating (single login, no extra latency)
- Captures: mode (SCHEDULE / ON / OFF), state (heating or not), boost active
- Daily runtime computed same as heating thermostats
- Shown in new 'Hive Hot Water' dashboard section

### Schema changes (auto-migrated)
New columns in \eadings\: \attery_voltage_mv\, \device_min_humidity_pct\, \device_max_humidity_pct\, \ssi\

### API
All new columns now included in \/api/readings\, \/api/readings/latest\, and \/api/export/csv\.