### PR TITLE
Fix Sonoff min/max, battery display, and Hive hot water

### DIFF
--- a/zigbee_sensor_reader/__main__.py
+++ b/zigbee_sensor_reader/__main__.py
@@ -174,6 +174,7 @@ async def run_collector(pair: bool = False) -> None:
         )
 
         next_sensor_poll = 0.0
+        next_min_max_poll = 0.0
         while True:
             await _process_onboarding_commands(listener, conn)
 
@@ -183,6 +184,16 @@ async def run_collector(pair: bool = False) -> None:
                 continue
 
             next_sensor_poll = now + POLLING_INTERVAL
+
+            # Every 10 minutes: explicitly read min/max attributes from SNZB-02DR2
+            # sensors to populate zigpy's cache (they're not always auto-reported).
+            if now >= next_min_max_poll:
+                next_min_max_poll = now + 600  # 10 minutes
+                try:
+                    from .zigbee_reader import poll_min_max_attributes
+                    await poll_min_max_attributes(listener.app)
+                except Exception as e:
+                    logger.debug("Min/max attribute poll skipped: %s", e)
 
             # Read cached Zigbee sensor values and store them
             try:

--- a/zigbee_sensor_reader/hive_reader.py
+++ b/zigbee_sensor_reader/hive_reader.py
@@ -112,9 +112,9 @@ async def fetch_hive_data() -> dict:
             friendly_name = HIVE_NAMES.get(hive_name, hive_name)
 
             try:
-                mode = await hive.hotwater.get_mode(dev)
-                state = await hive.hotwater.get_state(dev)
-                boost = await hive.hotwater.get_boost_status(dev)
+                mode = await hive.hotwater.getMode(dev)
+                state = await hive.hotwater.getState(dev)
+                boost = await hive.hotwater.getBoostStatus(dev)
 
                 hw_on = state not in ("OFF", None, False)
                 boost_active = boost not in ("OFF", None, False)

--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -314,7 +314,7 @@ def _calculate_hive_runtime_seconds(conn: sqlite3.Connection, day: str) -> dict:
         """
         SELECT ieee_address, timestamp, heating_on
         FROM readings
-        WHERE ieee_address LIKE 'hive:%'
+        WHERE (ieee_address LIKE 'hive:%' OR ieee_address LIKE 'hive-hw:%')
           AND substr(timestamp, 1, 10) = ?
         ORDER BY ieee_address, timestamp
         """,
@@ -724,7 +724,7 @@ def dashboard():
     <thead>
       <tr>
         <th>Sensor</th><th>Zone</th><th>Timestamp</th><th>Temp (&deg;C)</th><th>Humidity (%)</th>
-        <th>Device Min/Max Temp (&deg;C)</th><th>Today Low/High Temp (&deg;C)</th><th>Today Low/High Humidity (%)</th>
+        <th>Battery (%)</th><th>Device Min/Max Temp (&deg;C)</th><th>Today Low/High Temp (&deg;C)</th><th>Today Low/High Humidity (%)</th>
       </tr>
     </thead>
     <tbody>
@@ -735,6 +735,7 @@ def dashboard():
         <td>{{ s.timestamp }}</td>
         <td>{% if s.temperature_c is not none %}{{ "%.1f"|format(s.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if s.humidity_pct is not none %}{{ "%.1f"|format(s.humidity_pct) }}{% else %}-{% endif %}</td>
+        <td>{% if s.battery_pct is not none %}{{ "%.0f"|format(s.battery_pct) }}%{% else %}-{% endif %}</td>
         <td>
           {% if s.device_min_temp_c is not none and s.device_max_temp_c is not none %}
             {{ "%.1f"|format(s.device_min_temp_c) }} / {{ "%.1f"|format(s.device_max_temp_c) }}
@@ -760,7 +761,7 @@ def dashboard():
     <thead>
       <tr>
         <th>Thermostat</th><th>Zone</th><th>Timestamp</th><th>Current Temp (&deg;C)</th>
-        <th>Target Temp (&deg;C)</th><th>Mode</th><th>Status</th><th>Daily Runtime (HH:MM)</th>
+        <th>Target Temp (&deg;C)</th><th>Mode</th><th>Status</th><th>Battery (%)</th><th>Daily Runtime (HH:MM)</th>
       </tr>
     </thead>
     <tbody>
@@ -773,6 +774,7 @@ def dashboard():
         <td>{% if h.target_temp_c is not none %}{{ "%.1f"|format(h.target_temp_c) }}{% else %}-{% endif %}</td>
         <td>{{ h.heating_mode or "-" }}</td>
         <td class="status-{{ h.status }}">{{ h.status }}</td>
+        <td>{% if h.battery_pct is not none %}{{ "%.0f"|format(h.battery_pct) }}%{% else %}-{% endif %}</td>
         <td>{{ h.runtime_today_hhmm }}</td>
       </tr>
       {% endfor %}

--- a/zigbee_sensor_reader/zigbee_reader.py
+++ b/zigbee_sensor_reader/zigbee_reader.py
@@ -192,20 +192,43 @@ class ZigbeeSensorListener:
         )
 
         if cluster.cluster_id == TemperatureMeasurement.cluster_id:
-            # ZCL temperature is in units of 0.01°C
-            reading.temperature_c = value / 100.0
-            logger.info("%s temperature: %.1f°C", friendly, reading.temperature_c)
+            # ZCL temperature attrs: 0x0000=measured, 0x0001=min, 0x0002=max (units: 0.01°C)
+            if attrid == 0x0000:
+                reading.temperature_c = value / 100.0
+                logger.info("%s temperature: %.1f°C", friendly, reading.temperature_c)
+            elif attrid == 0x0001 and value != 0x8000:
+                reading.device_min_temp_c = value / 100.0
+                logger.debug("%s device min temp: %.1f°C", friendly, reading.device_min_temp_c)
+            elif attrid == 0x0002 and value != 0x8000:
+                reading.device_max_temp_c = value / 100.0
+                logger.debug("%s device max temp: %.1f°C", friendly, reading.device_max_temp_c)
+            else:
+                return
 
         elif cluster.cluster_id == RelativeHumidity.cluster_id:
-            # ZCL humidity is in units of 0.01%
-            reading.humidity_pct = value / 100.0
-            logger.info("%s humidity: %.1f%%", friendly, reading.humidity_pct)
+            # ZCL humidity attrs: 0x0000=measured, 0x0001=min, 0x0002=max (units: 0.01%)
+            if attrid == 0x0000:
+                reading.humidity_pct = value / 100.0
+                logger.info("%s humidity: %.1f%%", friendly, reading.humidity_pct)
+            elif attrid == 0x0001 and value != 0xFFFF:
+                reading.device_min_humidity_pct = value / 100.0
+                logger.debug("%s device min humidity: %.1f%%", friendly, reading.device_min_humidity_pct)
+            elif attrid == 0x0002 and value != 0xFFFF:
+                reading.device_max_humidity_pct = value / 100.0
+                logger.debug("%s device max humidity: %.1f%%", friendly, reading.device_max_humidity_pct)
+            else:
+                return
 
         elif cluster.cluster_id == PowerConfiguration.cluster_id:
-            # Battery percentage remaining
-            # ZCL reports battery percentage as 0-200 (0.5% steps)
-            reading.battery_pct = value / 2.0
-            logger.info("%s battery: %.0f%%", friendly, reading.battery_pct)
+            # 0x0021=battery_percentage_remaining (0-200, 0.5% steps), 0x0020=voltage (100mV)
+            if attrid == 0x0021:
+                reading.battery_pct = value / 2.0
+                logger.info("%s battery: %.0f%%", friendly, reading.battery_pct)
+            elif attrid == 0x0020:
+                reading.battery_voltage_mv = value * 100.0
+                logger.debug("%s battery voltage: %.0f mV", friendly, reading.battery_voltage_mv)
+            else:
+                return
 
         else:
             return  # Ignore clusters we don't care about
@@ -307,6 +330,49 @@ async def poll_sensors(app: ControllerApplication) -> list[SensorReading]:
                 readings.append(reading)
 
     return readings
+
+
+async def poll_min_max_attributes(app: ControllerApplication) -> None:
+    """
+    Actively read min/max measured values from all sensors.
+
+    The SNZB-02DR2 stores its rolling daily min/max in ZCL attributes
+    0x0001 (MinMeasuredValue) and 0x0002 (MaxMeasuredValue) but does not
+    always include them in periodic attribute reports.  Calling this
+    function populates zigpy's attribute cache so that the next
+    read_cached_sensors() call picks them up.
+
+    Call at a longer interval than the main poll (e.g. every 10 minutes).
+    """
+    for ieee, device in app.devices.items():
+        friendly = SENSOR_NAMES.get(str(ieee), str(ieee))
+        for ep_id, endpoint in device.endpoints.items():
+            if ep_id == 0:
+                continue
+
+            if TemperatureMeasurement.cluster_id in endpoint.in_clusters:
+                cluster = endpoint.in_clusters[TemperatureMeasurement.cluster_id]
+                try:
+                    await cluster.read_attributes(
+                        ["min_measured_value", "max_measured_value"]
+                    )
+                    logger.debug("Polled temp min/max from %s", friendly)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to poll temp min/max from %s: %s", friendly, exc
+                    )
+
+            if RelativeHumidity.cluster_id in endpoint.in_clusters:
+                cluster = endpoint.in_clusters[RelativeHumidity.cluster_id]
+                try:
+                    await cluster.read_attributes(
+                        ["min_measured_value", "max_measured_value"]
+                    )
+                    logger.debug("Polled humidity min/max from %s", friendly)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to poll humidity min/max from %s: %s", friendly, exc
+                    )
 
 
 def read_cached_sensors(app: ControllerApplication) -> list[SensorReading]:


### PR DESCRIPTION
## Summary

Fixes four issues with sensor data capture and display.

### SNZB-02DR2 daily min/max
- `_handle_attribute()` now checks `attrid` so min/max attribute reports (0x0001/0x0002) are mapped to `device_min/max_temp_c` instead of overwriting the current temperature
- New `poll_min_max_attributes()` actively reads min/max ZCL attributes every 10 minutes to populate zigpy's cache (the SNZB-02DR2 stores rolling daily min/max internally but doesn't always broadcast them)

### Battery level not displayed
- Added **Battery (%)** column to the Sonoff sensor dashboard table
- Added **Battery (%)** column to the Hive thermostat dashboard table
- Battery was already being stored in the DB — it just wasn't shown

### Hive hot water data missing
- Fixed hot water method names from snake_case (`get_mode` / `get_state` / `get_boost_status`) to camelCase (`getMode` / `getState` / `getBoostStatus`) matching the apyhiveapi convention — these were silently throwing `AttributeError` and producing no hot water data
- Fixed `_calculate_hive_runtime_seconds()` SQL query to include `hive-hw:%` addresses (previously `LIKE 'hive:%'` never matched `hive-hw:` so runtime was always 00:00)

### Files changed
- `zigbee_sensor_reader/zigbee_reader.py`
- `zigbee_sensor_reader/__main__.py`
- `zigbee_sensor_reader/hive_reader.py`
- `zigbee_sensor_reader/web_server.py`