### PR TITLE
Sync device names from Zigbee2MQTT + zone override UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ pyhive-integration>=1.0.0
 # Shelly Blu H&T BLE sensor support
 bleak>=0.21.0
 
+# Zigbee2MQTT name sync via MQTT
+paho-mqtt>=1.6.0
+
 # Web API for remote data access (Power BI, Excel, etc.)
 flask>=3.0.0
 

--- a/zigbee_sensor_reader/__main__.py
+++ b/zigbee_sensor_reader/__main__.py
@@ -159,6 +159,14 @@ async def run_collector(pair: bool = False) -> None:
     try:
         await listener.start()
 
+        # Start Zigbee2MQTT name sync in the background (non-fatal if unavailable)
+        try:
+            from .z2m_sync import run_z2m_sync
+            asyncio.create_task(run_z2m_sync(lambda: conn))
+            logger.info("Zigbee2MQTT name sync task started")
+        except Exception as exc:
+            logger.warning("z2m sync task could not start: %s", exc)
+
         if pair:
             logger.info(
                 "Pairing mode: network is open for 120 seconds. "

--- a/zigbee_sensor_reader/database.py
+++ b/zigbee_sensor_reader/database.py
@@ -34,6 +34,8 @@ def _create_tables(conn: sqlite3.Connection) -> None:
             friendly_name TEXT,
             model         TEXT,
             zone          TEXT,
+            zone_override TEXT,
+            name_source   TEXT DEFAULT 'config',
             first_seen    TEXT NOT NULL,
             last_seen     TEXT NOT NULL
         );
@@ -105,6 +107,8 @@ def _create_tables(conn: sqlite3.Connection) -> None:
     # Add columns to existing databases (safe to run multiple times)
     migrations = [
         ("sensors", "zone", "TEXT"),
+        ("sensors", "zone_override", "TEXT"),
+        ("sensors", "name_source", "TEXT"),
         ("readings", "zone", "TEXT"),
         ("readings", "heating_on", "INTEGER"),
         ("readings", "boost_on", "INTEGER"),
@@ -151,20 +155,72 @@ def upsert_sensor(
     friendly_name: str | None = None,
     model: str | None = None,
     zone: str | None = None,
+    name_source: str = "config",
 ) -> None:
-    """Insert or update a sensor in the registry."""
+    """Insert or update a sensor in the registry.
+
+    ``name_source`` should be ``"z2m"`` when the name comes from Zigbee2MQTT,
+    or ``"config"`` (default) when it comes from config.py.
+
+    z2m names always overwrite; config names only write when no z2m name
+    has been set yet (i.e. when name_source is not already 'z2m').
+    """
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    if name_source == "z2m":
+        # z2m always wins — unconditionally update name, model, and source
+        conn.execute(
+            """
+            INSERT INTO sensors (ieee_address, friendly_name, model, zone, name_source, first_seen, last_seen)
+            VALUES (?, ?, ?, ?, 'z2m', ?, ?)
+            ON CONFLICT(ieee_address) DO UPDATE SET
+                friendly_name = COALESCE(excluded.friendly_name, sensors.friendly_name),
+                model         = COALESCE(excluded.model, sensors.model),
+                zone          = COALESCE(excluded.zone, sensors.zone),
+                name_source   = 'z2m',
+                last_seen     = excluded.last_seen
+            """,
+            (ieee_address, friendly_name, model, zone, now, now),
+        )
+    else:
+        # config.py — only set the name if z2m hasn't already claimed it
+        conn.execute(
+            """
+            INSERT INTO sensors (ieee_address, friendly_name, model, zone, name_source, first_seen, last_seen)
+            VALUES (?, ?, ?, ?, 'config', ?, ?)
+            ON CONFLICT(ieee_address) DO UPDATE SET
+                friendly_name = CASE
+                    WHEN sensors.name_source = 'z2m' THEN sensors.friendly_name
+                    ELSE COALESCE(excluded.friendly_name, sensors.friendly_name)
+                END,
+                model         = COALESCE(excluded.model, sensors.model),
+                zone          = COALESCE(excluded.zone, sensors.zone),
+                name_source   = CASE
+                    WHEN sensors.name_source = 'z2m' THEN 'z2m'
+                    ELSE 'config'
+                END,
+                last_seen     = excluded.last_seen
+            """,
+            (ieee_address, friendly_name, model, zone, now, now),
+        )
+    conn.commit()
+
+
+def set_sensor_zone_override(
+    conn: sqlite3.Connection,
+    ieee_address: str,
+    zone_override: str | None,
+) -> None:
+    """Set (or clear) a dashboard zone override for a sensor.
+
+    ``zone_override=None`` clears the override so the config.py zone is used.
+    """
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
     conn.execute(
         """
-        INSERT INTO sensors (ieee_address, friendly_name, model, zone, first_seen, last_seen)
-        VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(ieee_address) DO UPDATE SET
-            friendly_name = COALESCE(excluded.friendly_name, sensors.friendly_name),
-            model         = COALESCE(excluded.model, sensors.model),
-            zone          = COALESCE(excluded.zone, sensors.zone),
-            last_seen     = excluded.last_seen
+        UPDATE sensors SET zone_override = ?, last_seen = ?
+        WHERE ieee_address = ?
         """,
-        (ieee_address, friendly_name, model, zone, now, now),
+        (zone_override, now, ieee_address),
     )
     conn.commit()
 

--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -352,11 +352,13 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
     latest_rows = conn.execute(
         """
         SELECT r.ieee_address, s.friendly_name, s.model, r.timestamp, r.reading_date, r.reading_time,
-               r.temperature_c, r.humidity_pct, r.battery_pct, r.zone,
+               r.temperature_c, r.humidity_pct, r.battery_pct,
+               COALESCE(s.zone_override, r.zone) AS zone,
                r.heating_on, r.boost_on, r.target_temp_c, r.heating_mode,
                r.device_min_temp_c, r.device_max_temp_c,
                r.device_min_humidity_pct, r.device_max_humidity_pct,
-               r.battery_voltage_mv, r.rssi
+               r.battery_voltage_mv, r.rssi,
+               s.zone_override, s.name_source
         FROM readings r
         INNER JOIN (
             SELECT ieee_address, MAX(timestamp) AS max_ts
@@ -496,6 +498,27 @@ def api_status():
         "latest_reading": latest,
         "server_time": datetime.now().isoformat(),
     })
+
+
+@app.route("/api/sensors/<path:ieee_address>/zone", methods=["PATCH"])
+def api_set_zone(ieee_address: str):
+    """Set or clear a zone override for a sensor.
+
+    Body (JSON): {"zone": "Zone 1"}  — set a zone
+                 {"zone": null}       — clear the override (revert to config.py)
+    """
+    from .database import set_sensor_zone_override
+    data = request.get_json(silent=True) or {}
+    zone_value = data.get("zone")  # None means clear
+    conn = get_db_write()
+    try:
+        set_sensor_zone_override(conn, ieee_address, zone_value or None)
+        return jsonify({"ok": True, "ieee_address": ieee_address, "zone_override": zone_value})
+    except Exception as exc:
+        logger.warning("Zone update failed for %s: %s", ieee_address, exc)
+        return jsonify({"ok": False, "error": str(exc)}), 500
+    finally:
+        conn.close()
 
 
 @app.route("/api/system")
@@ -713,6 +736,13 @@ def dashboard():
     .status-on { color: #0b7a0b; font-weight: bold; }
     .status-off { color: #a33; font-weight: bold; }
     .status-boost { color: #8a2be2; font-weight: bold; }
+    .zone-cell { white-space: nowrap; }
+    .zone-val { cursor: pointer; border-bottom: 1px dashed #aaa; }
+    .zone-val:hover { background: #fffbe6; }
+    .zone-edit { display: none; }
+    .zone-edit input { width: 90px; padding: 2px 4px; font-size: .9em; }
+    .zone-edit button { padding: 2px 6px; font-size: .85em; cursor: pointer; }
+    .z2m-badge { font-size: .7em; color: #1a73e8; margin-left: 4px; }
   </style>
 </head>
 <body>
@@ -730,8 +760,15 @@ def dashboard():
     <tbody>
       {% for s in sonoff %}
       <tr>
-        <td>{{ s.friendly_name or s.ieee_address }}</td>
-        <td>{{ s.zone or "-" }}</td>
+        <td>{{ s.friendly_name or s.ieee_address }}{% if s.name_source == 'z2m' %}<span class="z2m-badge" title="Name from Zigbee2MQTT">z2m</span>{% endif %}</td>
+        <td class="zone-cell" id="zc-{{ s.ieee_address }}">
+          <span class="zone-val" onclick="zoneEdit('{{ s.ieee_address }}','{{ s.zone or '' }}')" title="Click to edit zone">{{ s.zone or "-" }}</span>
+          <span class="zone-edit">
+            <input type="text" placeholder="e.g. Zone 1">
+            <button onclick="zoneSave('{{ s.ieee_address }}')">&#10003;</button>
+            <button onclick="zoneCancel('{{ s.ieee_address }}')">&#10007;</button>
+          </span>
+        </td>
         <td>{{ s.timestamp }}</td>
         <td>{% if s.temperature_c is not none %}{{ "%.1f"|format(s.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if s.humidity_pct is not none %}{{ "%.1f"|format(s.humidity_pct) }}{% else %}-{% endif %}</td>
@@ -768,7 +805,14 @@ def dashboard():
       {% for h in hive %}
       <tr>
         <td>{{ h.friendly_name or h.ieee_address }}</td>
-        <td>{{ h.zone or "-" }}</td>
+        <td class="zone-cell" id="zc-{{ h.ieee_address }}">
+          <span class="zone-val" onclick="zoneEdit('{{ h.ieee_address }}','{{ h.zone or '' }}')" title="Click to edit zone">{{ h.zone or "-" }}</span>
+          <span class="zone-edit">
+            <input type="text" placeholder="e.g. Zone 1">
+            <button onclick="zoneSave('{{ h.ieee_address }}')">&#10003;</button>
+            <button onclick="zoneCancel('{{ h.ieee_address }}')">&#10007;</button>
+          </span>
+        </td>
         <td>{{ h.timestamp }}</td>
         <td>{% if h.temperature_c is not none %}{{ "%.1f"|format(h.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if h.target_temp_c is not none %}{{ "%.1f"|format(h.target_temp_c) }}{% else %}-{% endif %}</td>
@@ -817,7 +861,14 @@ def dashboard():
       {% for s in shelly %}
       <tr>
         <td>{{ s.friendly_name or s.ieee_address }}</td>
-        <td>{{ s.zone or "-" }}</td>
+        <td class="zone-cell" id="zc-{{ s.ieee_address }}">
+          <span class="zone-val" onclick="zoneEdit('{{ s.ieee_address }}','{{ s.zone or '' }}')" title="Click to edit zone">{{ s.zone or "-" }}</span>
+          <span class="zone-edit">
+            <input type="text" placeholder="e.g. Zone 5">
+            <button onclick="zoneSave('{{ s.ieee_address }}')">&#10003;</button>
+            <button onclick="zoneCancel('{{ s.ieee_address }}')">&#10007;</button>
+          </span>
+        </td>
         <td>{{ s.timestamp }}</td>
         <td>{% if s.temperature_c is not none %}{{ "%.1f"|format(s.temperature_c) }}{% else %}-{% endif %}</td>
         <td>{% if s.humidity_pct is not none %}{{ "%.1f"|format(s.humidity_pct) }}{% else %}-{% endif %}</td>
@@ -838,6 +889,36 @@ def dashboard():
       {% endfor %}
     </tbody>
   </table>
+<script>
+function zoneEdit(ieee, currentZone) {
+  var cell = document.getElementById('zc-' + ieee);
+  var val = cell.querySelector('.zone-val');
+  var editDiv = cell.querySelector('.zone-edit');
+  var inp = editDiv.querySelector('input');
+  inp.value = currentZone === '-' ? '' : currentZone;
+  val.style.display = 'none';
+  editDiv.style.display = 'inline';
+  inp.focus();
+}
+function zoneSave(ieee) {
+  var cell = document.getElementById('zc-' + ieee);
+  var inp = cell.querySelector('.zone-edit input');
+  var newZone = inp.value.trim() || null;
+  fetch('/api/sensors/' + encodeURIComponent(ieee) + '/zone', {
+    method: 'PATCH',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({zone: newZone})
+  }).then(function(r){ return r.json(); }).then(function(d){
+    if (d.ok) { location.reload(); }
+    else { alert('Failed: ' + d.error); }
+  });
+}
+function zoneCancel(ieee) {
+  var cell = document.getElementById('zc-' + ieee);
+  cell.querySelector('.zone-val').style.display = '';
+  cell.querySelector('.zone-edit').style.display = 'none';
+}
+</script>
 </body>
 </html>
 """

--- a/zigbee_sensor_reader/z2m_sync.py
+++ b/zigbee_sensor_reader/z2m_sync.py
@@ -30,6 +30,12 @@ Z2M_MQTT_PORT = int(os.environ.get("Z2M_MQTT_PORT", "8081"))
 Z2M_MQTT_USER = os.environ.get("Z2M_MQTT_USER", "")
 Z2M_MQTT_PASS = os.environ.get("Z2M_MQTT_PASS", "")
 Z2M_TOPIC_PREFIX = os.environ.get("Z2M_TOPIC_PREFIX", "zigbee2mqtt")
+# Transport: "websockets" for port 8081 (Mosquitto WS), "tcp" for port 1883 (raw MQTT)
+# Defaults to "websockets" because port 1883 is not open on this installation.
+Z2M_MQTT_TRANSPORT = os.environ.get(
+    "Z2M_MQTT_TRANSPORT",
+    "tcp" if Z2M_MQTT_PORT == 1883 else "websockets",
+)
 
 
 def _normalise_ieee(ieee_raw: str) -> str:
@@ -149,7 +155,7 @@ async def run_z2m_sync(get_conn_fn) -> None:
             logger.warning("z2m MQTT disconnected unexpectedly (rc=%d)", rc)
 
     while True:
-        client = mqtt.Client()
+        client = mqtt.Client(transport=Z2M_MQTT_TRANSPORT)
         client.on_connect = on_connect
         client.on_message = on_message
         client.on_disconnect = on_disconnect
@@ -158,6 +164,10 @@ async def run_z2m_sync(get_conn_fn) -> None:
             client.username_pw_set(Z2M_MQTT_USER, Z2M_MQTT_PASS)
 
         try:
+            logger.info(
+                "z2m MQTT connecting to %s:%d (transport=%s)",
+                Z2M_MQTT_HOST, Z2M_MQTT_PORT, Z2M_MQTT_TRANSPORT,
+            )
             client.connect_async(Z2M_MQTT_HOST, Z2M_MQTT_PORT, keepalive=60)
             client.loop_start()
             # Keep the task alive; the paho background thread handles I/O

--- a/zigbee_sensor_reader/z2m_sync.py
+++ b/zigbee_sensor_reader/z2m_sync.py
@@ -1,0 +1,178 @@
+"""
+Zigbee2MQTT device name sync.
+
+Subscribes to the MQTT broker on the ``zigbee2mqtt/bridge/devices`` topic,
+which Zigbee2MQTT publishes on startup and whenever the device list changes.
+Friendly names from z2m always take priority over the names in config.py.
+
+Environment variables (all optional):
+    Z2M_MQTT_HOST  - MQTT broker hostname (default: home-logger)
+    Z2M_MQTT_PORT  - MQTT broker port     (default: 8081)
+    Z2M_MQTT_USER  - MQTT username        (default: empty)
+    Z2M_MQTT_PASS  - MQTT password        (default: empty)
+    Z2M_TOPIC_PREFIX - z2m topic prefix   (default: zigbee2mqtt)
+
+NOTE: Port 8081 is unusual for raw MQTT (Mosquitto default is 1883; 8081 is
+often the Zigbee2MQTT web UI or Mosquitto WebSocket port).  If the connection
+fails, check the port and set Z2M_MQTT_PORT accordingly.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+Z2M_MQTT_HOST = os.environ.get("Z2M_MQTT_HOST", "home-logger")
+Z2M_MQTT_PORT = int(os.environ.get("Z2M_MQTT_PORT", "8081"))
+Z2M_MQTT_USER = os.environ.get("Z2M_MQTT_USER", "")
+Z2M_MQTT_PASS = os.environ.get("Z2M_MQTT_PASS", "")
+Z2M_TOPIC_PREFIX = os.environ.get("Z2M_TOPIC_PREFIX", "zigbee2mqtt")
+
+
+def _normalise_ieee(ieee_raw: str) -> str:
+    """
+    Normalise a z2m IEEE address to the colon-separated lowercase format
+    used by zigpy / this codebase.
+
+    z2m stores IEEE addresses as ``0x00124b0025e7a1c3`` (hex string).
+    We convert to ``00:12:4b:00:25:e7:a1:c3``.
+    """
+    addr = ieee_raw.lower().strip()
+    if addr.startswith("0x"):
+        addr = addr[2:]
+    if ":" not in addr and len(addr) == 16:
+        addr = ":".join(addr[i:i+2] for i in range(0, 16, 2))
+    return addr
+
+
+def sync_z2m_devices(devices_payload: str, conn: sqlite3.Connection) -> int:
+    """
+    Parse a zigbee2mqtt/bridge/devices JSON payload and upsert friendly names.
+
+    Returns the number of sensors updated.
+    """
+    try:
+        devices = json.loads(devices_payload)
+    except json.JSONDecodeError as exc:
+        logger.warning("z2m devices payload is not valid JSON: %s", exc)
+        return 0
+
+    if not isinstance(devices, list):
+        logger.warning("z2m devices payload is not a list, skipping")
+        return 0
+
+    updated = 0
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        ieee_raw = dev.get("ieee_address") or dev.get("ieeeAddr", "")
+        if not ieee_raw:
+            continue
+        ieee = _normalise_ieee(ieee_raw)
+        friendly_name = dev.get("friendly_name") or dev.get("friendlyName", "")
+        if not friendly_name or friendly_name == ieee_raw:
+            # z2m uses the raw IEEE as the name when no name has been set
+            continue
+        model = (
+            dev.get("definition", {}).get("model")
+            or dev.get("modelID")
+            or dev.get("model_id")
+        )
+
+        try:
+            from .database import upsert_sensor
+            upsert_sensor(
+                conn,
+                ieee_address=ieee,
+                friendly_name=friendly_name,
+                model=model or None,
+                name_source="z2m",
+            )
+            updated += 1
+            logger.debug("z2m sync: %s → %s", ieee, friendly_name)
+        except Exception as exc:
+            logger.warning("z2m sync failed for %s: %s", ieee, exc)
+
+    if updated:
+        logger.info("z2m sync: updated %d device name(s)", updated)
+    return updated
+
+
+async def run_z2m_sync(get_conn_fn) -> None:
+    """
+    Long-running asyncio task: connects to the MQTT broker and subscribes to
+    the z2m bridge/devices topic.  Reconnects automatically on failure.
+
+    ``get_conn_fn`` is a zero-argument callable that returns an open
+    sqlite3.Connection (the main collector's shared connection).
+    """
+    try:
+        import paho.mqtt.client as mqtt
+    except ImportError:
+        logger.warning(
+            "paho-mqtt is not installed — z2m name sync disabled. "
+            "Install with: pip install paho-mqtt"
+        )
+        return
+
+    topic = f"{Z2M_TOPIC_PREFIX}/bridge/devices"
+    loop = asyncio.get_event_loop()
+
+    def on_connect(client, userdata, flags, rc):
+        if rc == 0:
+            logger.info(
+                "z2m MQTT connected to %s:%d, subscribing to %s",
+                Z2M_MQTT_HOST, Z2M_MQTT_PORT, topic,
+            )
+            client.subscribe(topic, qos=0)
+        else:
+            logger.warning(
+                "z2m MQTT connection refused (rc=%d) — "
+                "check host/port (Z2M_MQTT_HOST=%s, Z2M_MQTT_PORT=%d). "
+                "Note: raw MQTT default port is 1883; port 8081 is usually "
+                "the z2m web UI or Mosquitto WebSocket port.",
+                rc, Z2M_MQTT_HOST, Z2M_MQTT_PORT,
+            )
+
+    def on_message(client, userdata, msg):
+        try:
+            conn = get_conn_fn()
+            sync_z2m_devices(msg.payload.decode("utf-8"), conn)
+        except Exception as exc:
+            logger.warning("z2m on_message error: %s", exc)
+
+    def on_disconnect(client, userdata, rc):
+        if rc != 0:
+            logger.warning("z2m MQTT disconnected unexpectedly (rc=%d)", rc)
+
+    while True:
+        client = mqtt.Client()
+        client.on_connect = on_connect
+        client.on_message = on_message
+        client.on_disconnect = on_disconnect
+
+        if Z2M_MQTT_USER:
+            client.username_pw_set(Z2M_MQTT_USER, Z2M_MQTT_PASS)
+
+        try:
+            client.connect_async(Z2M_MQTT_HOST, Z2M_MQTT_PORT, keepalive=60)
+            client.loop_start()
+            # Keep the task alive; the paho background thread handles I/O
+            while True:
+                await asyncio.sleep(30)
+        except Exception as exc:
+            logger.warning(
+                "z2m MQTT connection to %s:%d failed: %s — retrying in 60s",
+                Z2M_MQTT_HOST, Z2M_MQTT_PORT, exc,
+            )
+        finally:
+            try:
+                client.loop_stop()
+                client.disconnect()
+            except Exception:
+                pass
+
+        await asyncio.sleep(60)


### PR DESCRIPTION
## Summary

Automatically pulls friendly device names from Zigbee2MQTT via MQTT, so you no longer need to duplicate names in `config.py`. Zones can still be set per-sensor from the dashboard.

### How it works
- A background task subscribes to `zigbee2mqtt/bridge/devices` on the MQTT broker (`home-logger:8081` by default)
- When z2m publishes its device list (on startup or device change), friendly names are synced into the `sensors` table
- **z2m names always win** — no manual override needed in `config.py`
- Sensors named by z2m show a small **z2m** badge in the dashboard

### Zone editing
- Zones are no longer needed in `config.py` (but still work as defaults if set)
- **Click any zone cell** in the dashboard to edit it inline — saves immediately via `PATCH /api/sensors/<ieee>/zone`
- Zone overrides are stored in a new `zone_override` column in the database
- Clear a zone override by saving an empty value (reverts to `config.py` zone)

### Configuration
All settings have defaults — no changes needed unless your setup differs:
| Env var | Default | Description |
|---|---|---|
| `Z2M_MQTT_HOST` | `home-logger` | MQTT broker hostname |
| `Z2M_MQTT_PORT` | `8081` | MQTT broker port |
| `Z2M_MQTT_USER` | _(empty)_ | MQTT username |
| `Z2M_MQTT_PASS` | _(empty)_ | MQTT password |
| `Z2M_TOPIC_PREFIX` | `zigbee2mqtt` | z2m topic prefix |

> **Note:** Port 8081 is unusual for raw MQTT (standard is 1883). If the connection fails, the log will clearly say so and you can adjust `Z2M_MQTT_PORT`.

### Files changed
- `zigbee_sensor_reader/z2m_sync.py` _(new)_
- `zigbee_sensor_reader/database.py`
- `zigbee_sensor_reader/__main__.py`
- `zigbee_sensor_reader/web_server.py`
- `requirements.txt`