### PR TITLE
Debug logging + z2m description as zone + Hive hot water method discovery

### DIFF
--- a/zigbee_sensor_reader/hive_reader.py
+++ b/zigbee_sensor_reader/hive_reader.py
@@ -99,22 +99,46 @@ async def fetch_hive_data() -> dict:
                 logger.warning("Failed to read Hive heating %s: %s", friendly_name, e)
 
         # ── Hot water ───────────────────────────────────────────────────────
-        # Try both common key names across library versions
+        # Log the full session key list so we can see exactly where hot water lives
+        logger.info("Hive session keys: %s", list(session.keys()))
+
+        # Try all known key names across library versions
         hw_devices = (
             session.get("water_heater")
+            or session.get("hotWater")
             or session.get("hotwater")
             or getattr(hive, "device_list", {}).get("water_heater")
+            or getattr(hive, "device_list", {}).get("hotWater")
             or []
         )
+        logger.info("Hive hot water devices found: %d", len(hw_devices))
         for dev in hw_devices:
             hive_name = dev.get("hiveName", dev.get("hive_name", "Hot Water"))
             device_id = dev.get("hiveID", dev.get("device_id", "hotwater"))
             friendly_name = HIVE_NAMES.get(hive_name, hive_name)
 
+            # Discover available methods on hive.hotwater at runtime
+            hw_api = hive.hotwater
+            def _try_hw(method_names, arg):
+                for name in method_names:
+                    fn = getattr(hw_api, name, None)
+                    if fn is not None:
+                        return fn, name
+                logger.warning(
+                    "hive.hotwater has none of %s — available: %s",
+                    method_names,
+                    [m for m in dir(hw_api) if not m.startswith("_")],
+                )
+                return None, None
+
             try:
-                mode = await hive.hotwater.getMode(dev)
-                state = await hive.hotwater.getState(dev)
-                boost = await hive.hotwater.getBoostStatus(dev)
+                get_mode_fn, _ = _try_hw(["getMode", "get_mode", "mode"], dev)
+                get_state_fn, _ = _try_hw(["getState", "get_state", "state"], dev)
+                get_boost_fn, _ = _try_hw(["getBoostStatus", "get_boost_status", "boostStatus"], dev)
+
+                mode = await get_mode_fn(dev) if get_mode_fn else None
+                state = await get_state_fn(dev) if get_state_fn else None
+                boost = await get_boost_fn(dev) if get_boost_fn else None
 
                 hw_on = state not in ("OFF", None, False)
                 boost_active = boost not in ("OFF", None, False)

--- a/zigbee_sensor_reader/z2m_sync.py
+++ b/zigbee_sensor_reader/z2m_sync.py
@@ -58,6 +58,9 @@ def sync_z2m_devices(devices_payload: str, conn: sqlite3.Connection) -> int:
     """
     Parse a zigbee2mqtt/bridge/devices JSON payload and upsert friendly names.
 
+    Also reads the device ``description`` field as a zone if set — this lets
+    you assign zones directly in the Zigbee2MQTT UI without editing config.py.
+
     Returns the number of sensors updated.
     """
     try:
@@ -79,17 +82,24 @@ def sync_z2m_devices(devices_payload: str, conn: sqlite3.Connection) -> int:
             continue
         ieee = _normalise_ieee(ieee_raw)
         friendly_name = dev.get("friendly_name") or dev.get("friendlyName", "")
-        if not friendly_name or friendly_name == ieee_raw:
-            # z2m uses the raw IEEE as the name when no name has been set
+        # Skip devices that have no custom name (z2m uses raw IEEE as default name)
+        if not friendly_name or friendly_name == ieee_raw or friendly_name == ieee:
             continue
         model = (
             dev.get("definition", {}).get("model")
             or dev.get("modelID")
             or dev.get("model_id")
         )
+        # Use the z2m description field as zone if set
+        zone_from_desc = dev.get("description") or None
+
+        logger.info(
+            "z2m device: raw_ieee=%s → normalised=%s name=%r zone=%r",
+            ieee_raw, ieee, friendly_name, zone_from_desc,
+        )
 
         try:
-            from .database import upsert_sensor
+            from .database import upsert_sensor, set_sensor_zone_override
             upsert_sensor(
                 conn,
                 ieee_address=ieee,
@@ -97,13 +107,21 @@ def sync_z2m_devices(devices_payload: str, conn: sqlite3.Connection) -> int:
                 model=model or None,
                 name_source="z2m",
             )
+            # If z2m has a description set, apply it as the zone override
+            if zone_from_desc:
+                set_sensor_zone_override(conn, ieee, zone_from_desc)
             updated += 1
-            logger.debug("z2m sync: %s → %s", ieee, friendly_name)
         except Exception as exc:
             logger.warning("z2m sync failed for %s: %s", ieee, exc)
 
     if updated:
         logger.info("z2m sync: updated %d device name(s)", updated)
+    else:
+        logger.info(
+            "z2m sync: no updates (received %d devices, none had custom names "
+            "or all names matched IEEE address)",
+            len(devices),
+        )
     return updated
 
 

--- a/zigbee_sensor_reader/zigbee_reader.py
+++ b/zigbee_sensor_reader/zigbee_reader.py
@@ -344,6 +344,7 @@ async def poll_min_max_attributes(app: ControllerApplication) -> None:
 
     Call at a longer interval than the main poll (e.g. every 10 minutes).
     """
+    logger.info("Polling min/max attributes from %d devices", len(list(app.devices.items())))
     for ieee, device in app.devices.items():
         friendly = SENSOR_NAMES.get(str(ieee), str(ieee))
         for ep_id, endpoint in device.endpoints.items():
@@ -353,24 +354,34 @@ async def poll_min_max_attributes(app: ControllerApplication) -> None:
             if TemperatureMeasurement.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[TemperatureMeasurement.cluster_id]
                 try:
-                    await cluster.read_attributes(
+                    result = await cluster.read_attributes(
                         ["min_measured_value", "max_measured_value"]
                     )
-                    logger.debug("Polled temp min/max from %s", friendly)
+                    min_val = result[0].get("min_measured_value")
+                    max_val = result[0].get("max_measured_value")
+                    logger.info(
+                        "Polled temp min/max from %s: min=%s max=%s",
+                        friendly, min_val, max_val,
+                    )
                 except Exception as exc:
-                    logger.debug(
+                    logger.info(
                         "Failed to poll temp min/max from %s: %s", friendly, exc
                     )
 
             if RelativeHumidity.cluster_id in endpoint.in_clusters:
                 cluster = endpoint.in_clusters[RelativeHumidity.cluster_id]
                 try:
-                    await cluster.read_attributes(
+                    result = await cluster.read_attributes(
                         ["min_measured_value", "max_measured_value"]
                     )
-                    logger.debug("Polled humidity min/max from %s", friendly)
+                    min_val = result[0].get("min_measured_value")
+                    max_val = result[0].get("max_measured_value")
+                    logger.info(
+                        "Polled humidity min/max from %s: min=%s max=%s",
+                        friendly, min_val, max_val,
+                    )
                 except Exception as exc:
-                    logger.debug(
+                    logger.info(
                         "Failed to poll humidity min/max from %s: %s", friendly, exc
                     )
 


### PR DESCRIPTION
## Summary

Three diagnostic/fix changes based on live testing feedback.

### Hive hot water still not showing
- Added `logger.info("Hive session keys: ...")` so we can see exactly what keys the Hive API returns after login
- Now tries `hotWater` (camelCase) in addition to `hotwater` / `water_heater`
- Hot water method names are now discovered at runtime — tries `getMode`, `get_mode`, etc. and logs all available methods on `hive.hotwater` if none match, so we can see the correct name

### z2m device name sync not working / duplicates
- IEEE address logging bumped to INFO so normalisation is visible in the service log (`raw_ieee=0x... → normalised=xx:xx:xx:xx:xx:xx:xx:xx`)
- Skip logic also now ignores devices where `friendly_name` equals the normalised IEEE (not just the raw hex)
- **Zone from z2m description**: if you set the `description` field for a device in the Zigbee2MQTT UI, it is now automatically applied as the zone override — no need to edit `config.py` or click zones in the dashboard

### SNZB-02DR2 min/max poll
- `poll_min_max_attributes` now logs at INFO level with the actual values returned, so we can see if sensors support the ZCL min/max attributes or if they return nothing

## After merging on the Pi
```bash
git pull origin main
sudo systemctl restart zigbee-sensor-reader sensor-data-api
journalctl -u zigbee-sensor-reader -f
```
Watch for `Hive session keys:`, `z2m device:`, and `Polled temp min/max` lines in the log.