### PR TITLE
Switch Zigbee collection from bellows/zigpy to Zigbee2MQTT MQTT

### DIFF
--- a/zigbee_sensor_reader/__main__.py
+++ b/zigbee_sensor_reader/__main__.py
@@ -12,21 +12,12 @@ Usage:
 import argparse
 import asyncio
 import logging
-import sys
 import time
 
 from .config import POLLING_INTERVAL, SENSOR_NAMES, ZONES
 from .database import get_connection, insert_reading, upsert_sensor
 from .export import export_to_csv, export_to_excel, get_sensor_summary
-from .onboarding import (
-    fetch_pending_commands,
-    mark_command_done,
-    mark_command_failed,
-    maybe_close_expired_pairing,
-    record_device_joined,
-    record_first_reading,
-    set_pairing_state,
-)
+from .onboarding import record_first_reading
 
 logging.basicConfig(
     level=logging.INFO,
@@ -93,128 +84,51 @@ def handle_reading(reading, conn) -> None:
     print("  ".join(parts))
 
 
-def _handle_device_joined(conn, ieee_address: str, model: str | None) -> None:
-    upsert_sensor(
-        conn,
-        ieee_address=ieee_address,
-        model=model,
-    )
-    record_device_joined(conn, ieee_address, model)
-
-
-async def _recover_listener_for_pairing(listener) -> None:
-    """Reinitialize the Zigbee listener to recover from stale EZSP transport state."""
-    try:
-        await listener.stop()
-    except Exception as exc:
-        logger.warning("Listener stop during pairing recovery failed: %s", exc)
-    await asyncio.sleep(1)
-    await listener.start()
-
-
-async def _process_onboarding_commands(listener, conn) -> None:
-    maybe_close_expired_pairing(conn)
-    for row in fetch_pending_commands(conn):
-        command_id = row["id"]
-        command = row["command"]
-        if command != "start_pairing":
-            mark_command_failed(conn, command_id, f"Unknown command: {command}")
-            continue
-
-        last_error = None
-        for attempt in (1, 2):
-            try:
-                await listener.permit_join(duration=120)
-                set_pairing_state(conn, active=True, duration_seconds=120)
-                mark_command_done(conn, command_id)
-                last_error = None
-                break
-            except Exception as exc:
-                last_error = exc
-                logger.warning("permit_join attempt %d failed: %s", attempt, exc)
-                if attempt == 1:
-                    await _recover_listener_for_pairing(listener)
-
-        if last_error is not None:
-            mark_command_failed(conn, command_id, f"permit_join failed: {last_error}")
-
-
 async def run_collector(pair: bool = False) -> None:
-    """Run the main data collection loop."""
-    # Import Zigbee dependencies only when actually collecting data
-    from .zigbee_reader import ZigbeeSensorListener
-
+    """Run the main data collection loop using Zigbee2MQTT via MQTT."""
     conn = get_connection()
     logger.info("Database ready at %s", conn.execute("PRAGMA database_list").fetchone()[2])
 
-    # Register any pre-configured sensor names
+    # Seed any pre-configured sensor names (config.py fallback, z2m will overwrite)
     for ieee, name in SENSOR_NAMES.items():
         upsert_sensor(conn, ieee_address=ieee, friendly_name=name, zone=ZONES.get(ieee))
 
-    listener = ZigbeeSensorListener(
-        on_reading=lambda reading: handle_reading(reading, conn),
-        on_device_joined=lambda ieee, model: _handle_device_joined(conn, ieee, model),
+    if pair:
+        logger.info(
+            "Note: pairing is managed by Zigbee2MQTT. "
+            "Use the z2m web UI at http://home-logger:8080 to permit joining."
+        )
+
+    logger.info(
+        "Starting data collection via Zigbee2MQTT MQTT (host=%s port=%d). "
+        "Hive poll interval: %ds",
+        __import__("os").environ.get("Z2M_MQTT_HOST", "home-logger"),
+        int(__import__("os").environ.get("Z2M_MQTT_PORT", "8081")),
+        POLLING_INTERVAL,
     )
 
     try:
-        await listener.start()
-
-        # Start Zigbee2MQTT name sync in the background (non-fatal if unavailable)
-        try:
-            from .z2m_sync import run_z2m_sync
-            asyncio.create_task(run_z2m_sync(lambda: conn))
-            logger.info("Zigbee2MQTT name sync task started")
-        except Exception as exc:
-            logger.warning("z2m sync task could not start: %s", exc)
-
-        if pair:
-            logger.info(
-                "Pairing mode: network is open for 120 seconds. "
-                "Put your sensor in pairing mode now (hold button 5+ seconds)."
+        from .z2m_reader import run_z2m_reader
+        asyncio.create_task(
+            run_z2m_reader(
+                on_reading=lambda reading: handle_reading(reading, conn),
+                get_conn_fn=lambda: conn,
             )
-            await listener.permit_join(duration=120)
-            set_pairing_state(conn, active=True, duration_seconds=120)
-
-        logger.info(
-            "Collecting sensor data (Ctrl+C to stop). "
-            "Polling interval: %ds",
-            POLLING_INTERVAL,
         )
+        logger.info("Zigbee2MQTT sensor reader started")
+    except Exception as exc:
+        logger.error("Could not start z2m reader: %s", exc)
 
-        next_sensor_poll = 0.0
-        next_min_max_poll = 0.0
+    try:
+        next_poll = 0.0
         while True:
-            await _process_onboarding_commands(listener, conn)
-
+            await asyncio.sleep(1)
             now = time.monotonic()
-            if now < next_sensor_poll:
-                await asyncio.sleep(1)
+            if now < next_poll:
                 continue
+            next_poll = now + POLLING_INTERVAL
 
-            next_sensor_poll = now + POLLING_INTERVAL
-
-            # Every 10 minutes: explicitly read min/max attributes from SNZB-02DR2
-            # sensors to populate zigpy's cache (they're not always auto-reported).
-            if now >= next_min_max_poll:
-                next_min_max_poll = now + 600  # 10 minutes
-                try:
-                    from .zigbee_reader import poll_min_max_attributes
-                    await poll_min_max_attributes(listener.app)
-                except Exception as e:
-                    logger.debug("Min/max attribute poll skipped: %s", e)
-
-            # Read cached Zigbee sensor values and store them
-            try:
-                from .zigbee_reader import read_cached_sensors
-                cached = read_cached_sensors(listener.app)
-                for reading in cached:
-                    handle_reading(reading, conn)
-                if cached:
-                    logger.info("Stored %d Zigbee sensor readings (cached)", len(cached))
-            except Exception as e:
-                logger.debug("Zigbee cache read failed: %s", e)
-
-            # Poll Hive if credentials are configured
+            # Poll Hive thermostats + hot water
             try:
                 from .hive_reader import poll_hive, HIVE_USERNAME
                 if HIVE_USERNAME:
@@ -228,14 +142,13 @@ async def run_collector(pair: bool = False) -> None:
                 from .config import SHELLY_SCAN_DURATION
                 await poll_shelly_ble(scan_duration=SHELLY_SCAN_DURATION)
             except ImportError:
-                pass  # bleak not installed (e.g. running on Windows dev machine)
+                pass  # bleak not installed
             except Exception as e:
                 logger.debug("Shelly BLE poll skipped: %s", e)
 
     except KeyboardInterrupt:
         logger.info("Shutting down...")
     finally:
-        await listener.stop()
         conn.close()
 
 

--- a/zigbee_sensor_reader/z2m_reader.py
+++ b/zigbee_sensor_reader/z2m_reader.py
@@ -1,0 +1,296 @@
+"""
+Zigbee2MQTT MQTT reader for sensor data.
+
+Subscribes to the MQTT broker and handles two topic families:
+  - zigbee2mqtt/bridge/devices  → sync friendly names + zones (from description)
+  - zigbee2mqtt/<friendly_name> → temperature, humidity, battery readings
+
+This replaces the bellows/zigpy direct-dongle approach.  Zigbee2MQTT already
+owns the coordinator; this module just reads what it publishes.
+
+Environment variables (all optional, same defaults as z2m_sync.py):
+    Z2M_MQTT_HOST      default: home-logger
+    Z2M_MQTT_PORT      default: 8081
+    Z2M_MQTT_USER      default: (empty)
+    Z2M_MQTT_PASS      default: (empty)
+    Z2M_MQTT_TRANSPORT default: websockets when port != 1883, else tcp
+    Z2M_TOPIC_PREFIX   default: zigbee2mqtt
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+Z2M_MQTT_HOST = os.environ.get("Z2M_MQTT_HOST", "home-logger")
+Z2M_MQTT_PORT = int(os.environ.get("Z2M_MQTT_PORT", "8081"))
+Z2M_MQTT_USER = os.environ.get("Z2M_MQTT_USER", "")
+Z2M_MQTT_PASS = os.environ.get("Z2M_MQTT_PASS", "")
+Z2M_TOPIC_PREFIX = os.environ.get("Z2M_TOPIC_PREFIX", "zigbee2mqtt")
+Z2M_MQTT_TRANSPORT = os.environ.get(
+    "Z2M_MQTT_TRANSPORT",
+    "tcp" if Z2M_MQTT_PORT == 1883 else "websockets",
+)
+
+
+def _normalise_ieee(ieee_raw: str) -> str:
+    """Convert 0xf4b3b1fffe60ae82 → f4:b3:b1:ff:fe:60:ae:82."""
+    addr = ieee_raw.lower().strip()
+    if addr.startswith("0x"):
+        addr = addr[2:]
+    if ":" not in addr and len(addr) == 16:
+        addr = ":".join(addr[i:i + 2] for i in range(0, 16, 2))
+    return addr
+
+
+class Z2MSensorReading:
+    """Sensor reading parsed from a zigbee2mqtt MQTT message."""
+
+    def __init__(
+        self,
+        ieee_address: str,
+        friendly_name: str,
+        model: str | None = None,
+        temperature_c: float | None = None,
+        humidity_pct: float | None = None,
+        battery_pct: float | None = None,
+        link_quality: int | None = None,
+        battery_voltage_mv: float | None = None,
+    ):
+        self.ieee_address = ieee_address
+        self.friendly_name = friendly_name
+        self.model = model
+        self.temperature_c = temperature_c
+        self.humidity_pct = humidity_pct
+        self.battery_pct = battery_pct
+        self.link_quality = link_quality
+        self.battery_voltage_mv = battery_voltage_mv
+        # z2m doesn't expose device-reported daily min/max — computed from readings instead
+        self.device_min_temp_c = None
+        self.device_max_temp_c = None
+        self.device_min_humidity_pct = None
+        self.device_max_humidity_pct = None
+
+
+ReadingCallback = Callable[[Z2MSensorReading], None]
+
+
+class Z2MReader:
+    """
+    Reads sensor data and device names from Zigbee2MQTT via MQTT.
+
+    Maintains an internal map of friendly_name → IEEE address built from
+    the zigbee2mqtt/bridge/devices topic.
+    """
+
+    def __init__(
+        self,
+        on_reading: ReadingCallback | None = None,
+        get_conn_fn: Callable[[], sqlite3.Connection] | None = None,
+    ):
+        self._on_reading = on_reading
+        self._get_conn = get_conn_fn
+        self._ieee_by_name: dict[str, str] = {}  # friendly_name → ieee
+        self._model_by_ieee: dict[str, str] = {}
+
+    def handle_message(self, topic: str, payload: str) -> None:
+        """Dispatch an incoming MQTT message."""
+        prefix = Z2M_TOPIC_PREFIX + "/"
+        if not topic.startswith(prefix):
+            return
+
+        remainder = topic[len(prefix):]
+
+        if remainder == "bridge/devices":
+            self._handle_bridge_devices(payload)
+        elif remainder.startswith("bridge/"):
+            pass  # ignore other bridge messages
+        else:
+            self._handle_sensor_message(remainder, payload)
+
+    def _handle_bridge_devices(self, payload: str) -> None:
+        """Sync friendly names, models and zones from the device list."""
+        try:
+            devices = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            logger.warning("z2m bridge/devices JSON error: %s", exc)
+            return
+        if not isinstance(devices, list):
+            return
+
+        updated = 0
+        for dev in devices:
+            if not isinstance(dev, dict):
+                continue
+            ieee_raw = dev.get("ieee_address") or dev.get("ieeeAddr", "")
+            if not ieee_raw:
+                continue
+            ieee = _normalise_ieee(ieee_raw)
+            name = dev.get("friendly_name") or dev.get("friendlyName", "")
+            # Skip devices that still use the raw IEEE as their name
+            if not name or name == ieee_raw or name == ieee:
+                continue
+
+            model = (
+                dev.get("definition", {}).get("model")
+                or dev.get("modelID")
+                or dev.get("model_id")
+            )
+            zone_from_desc = dev.get("description") or None
+
+            self._ieee_by_name[name] = ieee
+            if model:
+                self._model_by_ieee[ieee] = model
+
+            logger.info(
+                "z2m device: raw_ieee=%s → %s  name=%r  zone=%r",
+                ieee_raw, ieee, name, zone_from_desc,
+            )
+
+            if self._get_conn:
+                try:
+                    from .database import upsert_sensor, set_sensor_zone_override
+                    conn = self._get_conn()
+                    upsert_sensor(
+                        conn,
+                        ieee_address=ieee,
+                        friendly_name=name,
+                        model=model or None,
+                        name_source="z2m",
+                    )
+                    if zone_from_desc:
+                        set_sensor_zone_override(conn, ieee, zone_from_desc)
+                    updated += 1
+                except Exception as exc:
+                    logger.warning("z2m DB sync failed for %s: %s", ieee, exc)
+
+        logger.info("z2m bridge/devices: synced %d device(s)", updated)
+
+    def _handle_sensor_message(self, friendly_name: str, payload: str) -> None:
+        """Parse a sensor reading from a zigbee2mqtt/<name> message."""
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(data, dict):
+            return
+
+        # Must have at least temperature or humidity to be a sensor reading
+        temp = data.get("temperature")
+        humidity = data.get("humidity")
+        if temp is None and humidity is None:
+            return
+
+        ieee = self._ieee_by_name.get(friendly_name, friendly_name)
+        model = (
+            self._model_by_ieee.get(ieee)
+            or (data.get("device") or {}).get("model")
+        )
+
+        battery = data.get("battery")
+        lqi = data.get("linkquality") or data.get("link_quality")
+        # z2m reports Sonoff voltage in mV directly
+        voltage_mv = data.get("voltage")
+
+        reading = Z2MSensorReading(
+            ieee_address=ieee,
+            friendly_name=friendly_name,
+            model=model,
+            temperature_c=float(temp) if temp is not None else None,
+            humidity_pct=float(humidity) if humidity is not None else None,
+            battery_pct=float(battery) if battery is not None else None,
+            link_quality=int(lqi) if lqi is not None else None,
+            battery_voltage_mv=float(voltage_mv) if voltage_mv is not None else None,
+        )
+
+        logger.info(
+            "z2m reading [%s]: temp=%s°C  hum=%s%%  battery=%s%%",
+            friendly_name,
+            f"{temp:.1f}" if temp is not None else "-",
+            f"{humidity:.1f}" if humidity is not None else "-",
+            f"{battery:.0f}" if battery is not None else "-",
+        )
+
+        if self._on_reading:
+            self._on_reading(reading)
+
+
+async def run_z2m_reader(
+    on_reading: ReadingCallback | None = None,
+    get_conn_fn: Callable[[], sqlite3.Connection] | None = None,
+) -> None:
+    """
+    Long-running asyncio task: connect to the MQTT broker and read all
+    Zigbee2MQTT sensor messages.  Reconnects automatically on failure.
+    """
+    try:
+        import paho.mqtt.client as mqtt
+    except ImportError:
+        logger.error(
+            "paho-mqtt is not installed — Zigbee sensor collection disabled. "
+            "Install with: pip install paho-mqtt"
+        )
+        return
+
+    reader = Z2MReader(on_reading=on_reading, get_conn_fn=get_conn_fn)
+    devices_topic = f"{Z2M_TOPIC_PREFIX}/bridge/devices"
+    sensor_topic = f"{Z2M_TOPIC_PREFIX}/#"
+
+    def on_connect(client, userdata, flags, rc):
+        if rc == 0:
+            logger.info(
+                "z2m MQTT connected to %s:%d (%s) — subscribing",
+                Z2M_MQTT_HOST, Z2M_MQTT_PORT, Z2M_MQTT_TRANSPORT,
+            )
+            client.subscribe(sensor_topic, qos=0)
+        else:
+            logger.warning(
+                "z2m MQTT connection refused rc=%d (host=%s port=%d transport=%s)",
+                rc, Z2M_MQTT_HOST, Z2M_MQTT_PORT, Z2M_MQTT_TRANSPORT,
+            )
+
+    def on_message(client, userdata, msg):
+        try:
+            reader.handle_message(msg.topic, msg.payload.decode("utf-8", errors="replace"))
+        except Exception as exc:
+            logger.warning("z2m message handler error: %s", exc)
+
+    def on_disconnect(client, userdata, rc):
+        if rc != 0:
+            logger.warning("z2m MQTT disconnected unexpectedly (rc=%d)", rc)
+
+    while True:
+        client = mqtt.Client(transport=Z2M_MQTT_TRANSPORT)
+        client.on_connect = on_connect
+        client.on_message = on_message
+        client.on_disconnect = on_disconnect
+
+        if Z2M_MQTT_USER:
+            client.username_pw_set(Z2M_MQTT_USER, Z2M_MQTT_PASS)
+
+        try:
+            client.connect_async(Z2M_MQTT_HOST, Z2M_MQTT_PORT, keepalive=60)
+            client.loop_start()
+            logger.info(
+                "z2m MQTT connecting to %s:%d (transport=%s)",
+                Z2M_MQTT_HOST, Z2M_MQTT_PORT, Z2M_MQTT_TRANSPORT,
+            )
+            while True:
+                await asyncio.sleep(30)
+        except Exception as exc:
+            logger.warning(
+                "z2m MQTT error (%s:%d): %s — retrying in 60s",
+                Z2M_MQTT_HOST, Z2M_MQTT_PORT, exc,
+            )
+        finally:
+            try:
+                client.loop_stop()
+                client.disconnect()
+            except Exception:
+                pass
+
+        await asyncio.sleep(60)


### PR DESCRIPTION
## Root cause

Both this service (bellows/zigpy) and Zigbee2MQTT were trying to connect to the same Sonoff dongle TCP socket (`socket://192.168.1.59:6638`). Z2M wins that race, leaving bellows with `_gw = None` which cascades into `TypeError: object NoneType can't be used in 'await' expression` on every startup attempt.

## Fix: switch to Zigbee2MQTT MQTT for sensor data

Since Z2M is already running and collecting sensor data, subscribe to its MQTT topics instead of connecting to the dongle directly.

### New file: `z2m_reader.py`
- `Z2MReader` class subscribes to `zigbee2mqtt/#`
- `zigbee2mqtt/bridge/devices` → syncs friendly names, models, and `description`-as-zone to the DB (replaces `z2m_sync.py`)
- `zigbee2mqtt/<friendly_name>` → parses temperature, humidity, battery, voltage, linkquality and calls the reading callback
- `run_z2m_reader()` is a long-running asyncio task that reconnects automatically

### Updated: `__main__.py`
- `run_collector()` now starts `run_z2m_reader()` instead of `ZigbeeSensorListener`
- Hive thermostat/hot water polling unchanged
- Shelly BLE polling unchanged
- Bellows-specific code (onboarding permit_join, device join handler) removed — pairing is now done via the Z2M web UI at `http://home-logger:8080`

## After merging on the Pi
```bash
git pull origin main
sudo systemctl restart zigbee-sensor-reader sensor-data-api
journalctl -u zigbee-sensor-reader -f
```
You should immediately see `z2m MQTT connecting...` then `z2m bridge/devices: synced X device(s)` then individual sensor reading lines like `z2m reading [Living Room]: temp=21.5°C hum=65.2% battery=100%`