### PR TITLE
Fix missing sensors, duplicate IEEE rows, and z2m name sync on connect

### DIFF
--- a/zigbee_sensor_reader/database.py
+++ b/zigbee_sensor_reader/database.py
@@ -147,6 +147,60 @@ def _create_tables(conn: sqlite3.Connection) -> None:
         (now,),
     )
     conn.commit()
+    _migrate_normalise_ieee(conn)
+
+
+def _normalise_ieee(raw: str) -> str:
+    """Convert 0xaabbccddeeff0011 → aa:bb:cc:dd:ee:ff:00:11."""
+    addr = raw.lower().strip()
+    if addr.startswith("0x"):
+        addr = addr[2:]
+    if ":" not in addr and len(addr) == 16:
+        addr = ":".join(addr[i:i + 2] for i in range(0, 16, 2))
+    return addr
+
+
+def _migrate_normalise_ieee(conn: sqlite3.Connection) -> None:
+    """One-time migration: normalise raw 0x... IEEE addresses to colon format.
+
+    Old bellows-era rows may have been stored as '0xf4b3b1fffe60ae82' while
+    new z2m rows use 'f4:b3:b1:ff:fe:60:ae:82'.  This merges duplicate rows
+    and re-points all readings to the canonical colon-format key.
+    """
+    raw_rows = conn.execute(
+        "SELECT ieee_address FROM sensors WHERE ieee_address LIKE '0x%'"
+    ).fetchall()
+    if not raw_rows:
+        return
+
+    for row in raw_rows:
+        raw_ieee = row["ieee_address"]
+        canon = _normalise_ieee(raw_ieee)
+        if canon == raw_ieee:
+            continue  # already normalised (shouldn't happen if LIKE '0x%')
+
+        existing = conn.execute(
+            "SELECT ieee_address FROM sensors WHERE ieee_address = ?", (canon,)
+        ).fetchone()
+
+        if existing:
+            # Canonical form already exists — re-point readings then drop the raw row
+            conn.execute(
+                "UPDATE readings SET ieee_address = ? WHERE ieee_address = ?",
+                (canon, raw_ieee),
+            )
+            conn.execute("DELETE FROM sensors WHERE ieee_address = ?", (raw_ieee,))
+        else:
+            # Canonical form doesn't exist — just rename in place
+            conn.execute(
+                "UPDATE sensors SET ieee_address = ? WHERE ieee_address = ?",
+                (canon, raw_ieee),
+            )
+            conn.execute(
+                "UPDATE readings SET ieee_address = ? WHERE ieee_address = ?",
+                (canon, raw_ieee),
+            )
+    conn.commit()
 
 
 def upsert_sensor(

--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -461,6 +461,9 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
             sonoff.append(sensor_row)
         elif ieee_address.startswith("shelly:") or model == "Shelly Blu H&T":
             shelly.append(sensor_row)
+        else:
+            # Any other Zigbee sensor (unknown model, other Sonoff models, etc.)
+            sonoff.append(sensor_row)
 
     sonoff.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
     hive.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))

--- a/zigbee_sensor_reader/z2m_reader.py
+++ b/zigbee_sensor_reader/z2m_reader.py
@@ -107,6 +107,17 @@ class Z2MReader:
 
         if remainder == "bridge/devices":
             self._handle_bridge_devices(payload)
+        elif remainder == "bridge/response/devices":
+            # Response to our bridge/request/devices — contains a 'data' wrapper
+            try:
+                resp = json.loads(payload)
+                devices_payload = resp.get("data", payload) if isinstance(resp, dict) else payload
+                if isinstance(devices_payload, list):
+                    self._handle_bridge_devices(json.dumps(devices_payload))
+                elif isinstance(devices_payload, str):
+                    self._handle_bridge_devices(devices_payload)
+            except Exception:
+                pass
         elif remainder.startswith("bridge/"):
             pass  # ignore other bridge messages
         else:
@@ -246,6 +257,8 @@ async def run_z2m_reader(
                 Z2M_MQTT_HOST, Z2M_MQTT_PORT, Z2M_MQTT_TRANSPORT,
             )
             client.subscribe(sensor_topic, qos=0)
+            # Request z2m to re-publish the full device list so we get names/zones
+            client.publish(f"{Z2M_TOPIC_PREFIX}/bridge/request/devices", "", qos=0)
         else:
             logger.warning(
                 "z2m MQTT connection refused rc=%d (host=%s port=%d transport=%s)",


### PR DESCRIPTION
## Issues fixed

### 1. Missing sensors in dashboard
The Sonoff table only showed sensors whose `model` started with `SNZB-02`. Any sensor with a `NULL` model or a different model string silently fell through with no `else` clause — it appeared in none of the tables. Fixed with a catch-all: any sensor that isn't `hive:` or `shelly:` goes into the Sonoff/Zigbee table.

### 2. Duplicate entries from old raw IEEE format
Sensors seen before z2m sync was set up were stored with raw hex IEEE addresses (`0xf4b3b1fffe60ae82`). The new z2m-synced rows use colon format (`f4:b3:b1:ff:fe:60:ae:82`). Since SQLite uses IEEE as the primary key, these appeared as two separate rows.

New `_migrate_normalise_ieee()` runs on every startup:
- Finds any `sensors` row with a `0x`-prefixed address
- If a colon-format row already exists: re-points all readings to it, deletes the raw row
- If no colon-format row exists: renames both the sensor and its readings in place

### 3. z2m names/zones not syncing on service restart
z2m only publishes `bridge/devices` spontaneously at startup. If our service starts after z2m, we'd miss that message and have no friendly names until z2m re-publishes (which could be hours away).

Fix: on MQTT connect, immediately publish to `zigbee2mqtt/bridge/request/devices` which triggers z2m to re-send the full device list. Also handle `bridge/response/devices` (the direct reply) in addition to the periodic `bridge/devices` topic.

## After merging on the Pi (pull PRs #24 + #25)
```bash
git pull origin main
sudo systemctl restart zigbee-sensor-reader sensor-data-api
journalctl -u zigbee-sensor-reader -f
```
On startup you should immediately see `z2m bridge/devices: synced N device(s)` with all device names and zones applied. All 13 Sonoff sensors will appear in the dashboard. The "banca room" duplicate will be merged and updated to the current z2m name.