### PR TITLE
Fix dashboard duplicates, sort order, and Hive plug section

### DIFF
--- a/zigbee_sensor_reader/web_server.py
+++ b/zigbee_sensor_reader/web_server.py
@@ -118,6 +118,19 @@ def _zone_sort_key(zone: str | None) -> tuple[int, str]:
     return (999, zone)
 
 
+def _is_plug_row(ieee_address: str, model: str | None, friendly_name: str | None) -> bool:
+    """Heuristic to classify smart plugs into their own dashboard section."""
+    model_l = (model or "").lower()
+    name_l = (friendly_name or "").lower()
+    if model_l.startswith("ts011f"):
+        return True
+    if "plug" in model_l or "socket" in model_l:
+        return True
+    if "plug" in name_l or "socket" in name_l:
+        return True
+    return False
+
+
 def _get_system_info() -> dict:
     """
     Gather Pi hardware stats, service status, and database metrics.
@@ -361,10 +374,10 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
                s.zone_override, s.name_source
         FROM readings r
         INNER JOIN (
-            SELECT ieee_address, MAX(timestamp) AS max_ts
+            SELECT ieee_address, MAX(id) AS max_id
             FROM readings
             GROUP BY ieee_address
-        ) latest ON r.ieee_address = latest.ieee_address AND r.timestamp = latest.max_ts
+        ) latest ON r.id = latest.max_id
         LEFT JOIN sensors s ON r.ieee_address = s.ieee_address
         ORDER BY s.friendly_name
         """
@@ -391,6 +404,7 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
     shelly = []
     hive = []
     hotwater = []
+    plugs = []
 
     for row in latest_rows:
         ieee_address = row["ieee_address"]
@@ -457,7 +471,9 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
             "device_max_temp_c": latest.get("device_max_temp_c"),
         }
 
-        if model.startswith("SNZB-02"):
+        if _is_plug_row(ieee_address, model, latest.get("friendly_name")):
+            plugs.append(sensor_row)
+        elif model.startswith("SNZB-02"):
             sonoff.append(sensor_row)
         elif ieee_address.startswith("shelly:") or model == "Shelly Blu H&T":
             shelly.append(sensor_row)
@@ -465,10 +481,11 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
             # Any other Zigbee sensor (unknown model, other Sonoff models, etc.)
             sonoff.append(sensor_row)
 
-    sonoff.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
-    hive.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
+    sonoff.sort(key=lambda row: (_zone_sort_key(row.get("zone")), (row.get("friendly_name") or row.get("ieee_address") or "").lower()))
+    hive.sort(key=lambda row: (_zone_sort_key(row.get("zone")), (row.get("friendly_name") or row.get("ieee_address") or "").lower()))
     hotwater.sort(key=lambda row: (row.get("friendly_name") or row.get("ieee_address")))
-    shelly.sort(key=lambda row: (_zone_sort_key(row.get("zone")), row.get("friendly_name") or row.get("ieee_address")))
+    shelly.sort(key=lambda row: (_zone_sort_key(row.get("zone")), (row.get("friendly_name") or row.get("ieee_address") or "").lower()))
+    plugs.sort(key=lambda row: (_zone_sort_key(row.get("zone")), (row.get("friendly_name") or row.get("ieee_address") or "").lower()))
 
     return {
         "date_local": today_local,
@@ -480,6 +497,7 @@ def _build_dashboard_snapshot(conn: sqlite3.Connection) -> dict:
         "shelly": shelly,
         "hive": hive,
         "hotwater": hotwater,
+        "plugs": plugs,
     }
 
 
@@ -890,6 +908,37 @@ def dashboard():
         </td>
       </tr>
       {% endfor %}
+    </tbody>
+  </table>
+
+  <h2>Hive Plugs</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Plug</th><th>Zone</th><th>Timestamp</th><th>Temp (&deg;C)</th><th>Humidity (%)</th><th>Battery (%)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in plugs %}
+      <tr>
+        <td>{{ p.friendly_name or p.ieee_address }}{% if p.name_source == 'z2m' %}<span class="z2m-badge" title="Name from Zigbee2MQTT">z2m</span>{% endif %}</td>
+        <td class="zone-cell" id="zc-{{ p.ieee_address }}">
+          <span class="zone-val" onclick="zoneEdit('{{ p.ieee_address }}','{{ p.zone or '' }}')" title="Click to edit zone">{{ p.zone or "-" }}</span>
+          <span class="zone-edit">
+            <input type="text" placeholder="e.g. Zone 1">
+            <button onclick="zoneSave('{{ p.ieee_address }}')">&#10003;</button>
+            <button onclick="zoneCancel('{{ p.ieee_address }}')">&#10007;</button>
+          </span>
+        </td>
+        <td>{{ p.timestamp }}</td>
+        <td>{% if p.temperature_c is not none %}{{ "%.1f"|format(p.temperature_c) }}{% else %}-{% endif %}</td>
+        <td>{% if p.humidity_pct is not none %}{{ "%.1f"|format(p.humidity_pct) }}{% else %}-{% endif %}</td>
+        <td>{% if p.battery_pct is not none %}{{ "%.0f"|format(p.battery_pct) }}%{% else %}-{% endif %}</td>
+      </tr>
+      {% endfor %}
+      {% if not plugs %}
+      <tr><td colspan="6" style="color:#999">No plug data</td></tr>
+      {% endif %}
     </tbody>
   </table>
 <script>

--- a/zigbee_sensor_reader/z2m_reader.py
+++ b/zigbee_sensor_reader/z2m_reader.py
@@ -47,6 +47,16 @@ def _normalise_ieee(ieee_raw: str) -> str:
     return addr
 
 
+def _looks_like_ieee(value: str) -> bool:
+    addr = value.lower().strip()
+    if addr.startswith("0x"):
+        addr = addr[2:]
+    if ":" in addr:
+        parts = addr.split(":")
+        return len(parts) == 8 and all(len(p) == 2 for p in parts)
+    return len(addr) == 16
+
+
 class Z2MSensorReading:
     """Sensor reading parsed from a zigbee2mqtt MQTT message."""
 
@@ -195,7 +205,20 @@ class Z2MReader:
         if temp is None and humidity is None:
             return
 
-        ieee = self._ieee_by_name.get(friendly_name, friendly_name)
+        ieee = self._ieee_by_name.get(friendly_name)
+        if not ieee:
+            raw_ieee = (data.get("device") or {}).get("ieee_address")
+            if raw_ieee:
+                ieee = _normalise_ieee(str(raw_ieee))
+                self._ieee_by_name[friendly_name] = ieee
+            elif _looks_like_ieee(friendly_name):
+                ieee = _normalise_ieee(friendly_name)
+            else:
+                logger.debug(
+                    "z2m skipping reading for unknown device name %r until bridge/devices maps it",
+                    friendly_name,
+                )
+                return
         model = (
             self._model_by_ieee.get(ieee)
             or (data.get("device") or {}).get("model")


### PR DESCRIPTION
## Fixes included

1. Dashboard duplicate rows for the same sensor:
- Changed latest reading selection from `MAX(timestamp)` to `MAX(id)`.
- This removes duplicate rows caused by multiple readings with identical second-level timestamps.

2. Hive plugs shown under Sonoff sensors:
- Added plug classification (`TS011F`, `plug`, `socket`) and moved these devices to a dedicated **Hive Plugs** section at the bottom of the dashboard.

3. Sorting:
- Ensured dashboard sections are sorted by **zone first**, then **sensor name alphabetically** (case-insensitive).

4. Future duplicate prevention in z2m ingestion:
- z2m reader no longer uses unknown friendly names as fallback IEEE keys.
- If mapping is not yet known, it uses payload `device.ieee_address` when available; otherwise skips until bridge mapping arrives.
- This prevents new duplicate sensor rows when messages arrive before bridge device sync.